### PR TITLE
[codex] Fix reader issues and Android CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,81 @@
+name: Android CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: android-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    env:
+      ANDROID_NDK_VERSION: 28.2.13676358
+      ANDROID_CMAKE_VERSION: 3.22.1
+
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,x86_64-linux-android
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/git
+            ~/.cargo/registry
+            app/src/main/rust/hoshiepub/target
+          key: cargo-${{ runner.os }}-${{ hashFiles('app/src/main/rust/hoshiepub/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: Install Android SDK components
+        run: |
+          sdkmanager --install \
+            "platforms;android-36.1" \
+            "build-tools;36.0.0" \
+            "ndk;${ANDROID_NDK_VERSION}" \
+            "cmake;${ANDROID_CMAKE_VERSION}"
+          echo "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}" >> "${GITHUB_ENV}"
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
+
+      - name: Build, lint, and unit test
+        run: ./gradlew check --console=plain --stacktrace
+
+      - name: Assemble debug APK
+        run: ./gradlew assembleDebug --console=plain --stacktrace
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: hoshi-reader-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -35,6 +35,9 @@ jobs:
           distribution: temurin
           java-version: "17"
 
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v4
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
@@ -7,8 +9,12 @@ plugins {
 val rustProjectDir = file("src/main/rust/hoshiepub")
 val uniffiOutDir = layout.buildDirectory.dir("generated/source/uniffi/main/kotlin").get().asFile
 val rustJniLibsDir = layout.buildDirectory.dir("jniLibs").get().asFile
-val cargo = System.getenv("HOME") + "/.cargo/bin/cargo"
-val androidNdkHome = System.getenv("ANDROID_NDK_HOME") ?: "/opt/homebrew/share/android-ndk"
+val localProperties = Properties().apply {
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.isFile) {
+        localPropertiesFile.inputStream().use { load(it) }
+    }
+}
 val releaseKeystorePath = providers.environmentVariable("ANDROID_KEYSTORE_FILE").orNull
 val releaseKeystorePassword = providers.environmentVariable("ANDROID_KEYSTORE_PASSWORD").orNull
 val releaseKeyAlias = providers.environmentVariable("ANDROID_KEY_ALIAS").orNull
@@ -30,10 +36,40 @@ if (isReleaseSigningRequested && !isReleaseSigningConfigured) {
     )
 }
 
+val osName = System.getProperty("os.name").lowercase()
+val isWindows = osName.contains("win")
+val sdkDir = localProperties.getProperty("sdk.dir")?.takeIf { it.isNotBlank() }
+    ?: providers.environmentVariable("ANDROID_HOME").orNull?.takeIf { it.isNotBlank() }
+    ?: providers.environmentVariable("ANDROID_SDK_ROOT").orNull?.takeIf { it.isNotBlank() }
+val androidNdkHome = providers.environmentVariable("ANDROID_NDK_HOME").orNull?.takeIf { it.isNotBlank() }
+    ?: localProperties.getProperty("ndk.dir")?.takeIf { it.isNotBlank() }
+    ?: sdkDir
+        ?.let { file("$it/ndk") }
+        ?.takeIf { it.isDirectory }
+        ?.listFiles()
+        ?.filter { it.isDirectory }
+        ?.maxByOrNull { it.name }
+        ?.absolutePath
+    ?: "/opt/homebrew/share/android-ndk"
+val cargoBinaryName = if (isWindows) "cargo.exe" else "cargo"
+val cargo = providers.environmentVariable("CARGO").orNull?.takeIf { it.isNotBlank() }
+    ?: listOfNotNull(
+        System.getenv("HOME"),
+        System.getenv("USERPROFILE"),
+    ).asSequence()
+        .map { file("$it/.cargo/bin/$cargoBinaryName") }
+        .firstOrNull { it.isFile }
+        ?.absolutePath
+    ?: cargoBinaryName
+
 val hostLibExtension = when {
-    System.getProperty("os.name").lowercase().contains("mac") -> "dylib"
-    System.getProperty("os.name").lowercase().contains("win") -> "dll"
+    osName.contains("mac") -> "dylib"
+    isWindows -> "dll"
     else -> "so"
+}
+val hostLibName = when {
+    isWindows -> "hoshiepub.$hostLibExtension"
+    else -> "libhoshiepub.$hostLibExtension"
 }
 
 android {
@@ -135,7 +171,7 @@ val generateUniffiKotlin by tasks.registering(Exec::class) {
     dependsOn(buildRustHost)
     workingDir = rustProjectDir
 
-    val hostLibPath = rustProjectDir.resolve("target/debug/libhoshiepub.$hostLibExtension")
+    val hostLibPath = rustProjectDir.resolve("target/debug/$hostLibName")
 
     commandLine(
         cargo,

--- a/app/src/main/java/moe/antimony/hoshi/features/audio/AudioView.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/audio/AudioView.kt
@@ -260,11 +260,16 @@ fun AudioSettingsView(
                         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                         headlineContent = { Text("Background Audio") },
                         supportingContent = {
-                            SingleChoiceSegmentedButtonRow(modifier = Modifier.padding(top = 8.dp)) {
+                            SingleChoiceSegmentedButtonRow(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(top = 8.dp),
+                            ) {
                                 AudioPlaybackMode.entries.forEachIndexed { index, mode ->
                                     SegmentedButton(
                                         selected = settings.playbackMode == mode,
                                         onClick = { save(settings.copy(playbackMode = mode)) },
+                                        modifier = Modifier.weight(1f),
                                         shape = SegmentedButtonDefaults.itemShape(index, AudioPlaybackMode.entries.size),
                                     ) {
                                         Text(mode.displayName)

--- a/app/src/main/java/moe/antimony/hoshi/features/bookshelf/BookshelfView.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/bookshelf/BookshelfView.kt
@@ -896,6 +896,7 @@ private fun EmptyBooksView(
             text = "No Books",
             style = MaterialTheme.typography.headlineMedium,
             fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
         )
         Spacer(Modifier.height(10.dp))
         Text(

--- a/app/src/main/java/moe/antimony/hoshi/features/bookshelf/BookshelfView.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/bookshelf/BookshelfView.kt
@@ -336,7 +336,7 @@ fun BookshelfView(
                         SettingsDestination.ReportIssue -> context.startActivity(
                             Intent(
                                 Intent.ACTION_VIEW,
-                                Uri.parse("https://github.com/Manhhao/Hoshi-Reader/issues"),
+                                Uri.parse(ReportIssueUrl),
                             ),
                         )
                         else -> settingsDestination = destination

--- a/app/src/main/java/moe/antimony/hoshi/features/bookshelf/MainShellUi.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/bookshelf/MainShellUi.kt
@@ -17,6 +17,8 @@ enum class SettingsDestination {
     About,
 }
 
+const val ReportIssueUrl = "https://github.com/HuangAntimony/Hoshi-Reader-Android/issues"
+
 data class SettingsRowModel(
     val label: String,
     val destination: SettingsDestination,

--- a/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderChapterSheet.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderChapterSheet.kt
@@ -65,6 +65,7 @@ internal fun ReaderChapterSheet(
     ModalBottomSheet(
         onDismissRequest = onDismiss,
         containerColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.97f),
+        contentColor = MaterialTheme.colorScheme.onSurface,
         dragHandle = {},
     ) {
         LazyColumn(
@@ -91,6 +92,7 @@ internal fun ReaderChapterSheet(
                             .padding(top = 26.dp),
                         style = MaterialTheme.typography.headlineSmall,
                         fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.onSurface,
                     )
                     Surface(
                         modifier = Modifier.align(Alignment.CenterEnd),
@@ -173,6 +175,7 @@ private fun ReaderChapterBookHeader(
                 text = book.title,
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.Bold,
+                color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
             )
             Text(

--- a/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderContentStyles.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderContentStyles.kt
@@ -108,8 +108,8 @@ internal object ReaderContentStyles {
         img.block-img {
             max-width: var(--hoshi-image-max-width, ${settings.imageMaxWidthFallbackCss}) !important;
             max-height: var(--hoshi-image-max-height, ${settings.imageMaxHeightFallbackCss}) !important;
-            width: var(--hoshi-image-max-width, ${settings.imageMaxWidthFallbackCss}) !important;
-            height: var(--hoshi-image-max-height, ${settings.imageMaxHeightFallbackCss}) !important;
+            width: auto !important;
+            height: auto !important;
             display: block !important;
             margin: auto !important;
             break-inside: avoid !important;
@@ -119,8 +119,8 @@ internal object ReaderContentStyles {
         svg {
             max-width: var(--hoshi-image-max-width, ${settings.imageMaxWidthFallbackCss}) !important;
             max-height: var(--hoshi-image-max-height, ${settings.imageMaxHeightFallbackCss}) !important;
-            width: 100% !important;
-            height: 100% !important;
+            width: auto !important;
+            height: auto !important;
             display: block !important;
             margin: auto !important;
             break-inside: avoid !important;

--- a/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderContentStyles.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderContentStyles.kt
@@ -83,9 +83,12 @@ internal object ReaderContentStyles {
         $pageBreakCss
         @media (prefers-color-scheme: light) { :root { --hoshi-system-text-color: #000; } }
         @media (prefers-color-scheme: dark) { :root { --hoshi-system-text-color: #fff; } }
+        * {
+            max-width: 100% !important;
+            box-sizing: border-box !important;
+        }
         html, body {
             overflow: hidden !important;
-            height: var(--page-height, 100vh) !important;
             width: var(--page-width, 100vw) !important;
             margin: 0 !important;
             padding: 0 !important;
@@ -93,17 +96,42 @@ internal object ReaderContentStyles {
             color: $textColor !important;
             writing-mode: ${settings.writingModeCss} !important;
         }
+        html {
+            height: var(--page-height, 100vh) !important;
+        }
         body {
+            height: ${settings.bodyHeightCss} !important;
             font-family: $fontFamily, serif !important;
             font-size: ${settings.fontSize}px !important;
             $textSpacingCss
             box-sizing: border-box !important;
-            column-width: var(--page-width, 100vw) !important;
+            column-width: ${settings.columnWidthCss} !important;
             column-gap: ${settings.columnGapCss};
+            column-fill: auto !important;
+            -webkit-column-fill: auto !important;
+            overflow-wrap: anywhere !important;
+            word-break: normal !important;
+            orphans: 1;
+            widows: 1;
             padding: ${settings.pagePaddingCss} !important;
             padding-bottom: ${settings.bottomPaddingCss} !important;
             $gridCss
             text-orientation: mixed;
+        }
+        p, div, span, li {
+            break-inside: auto !important;
+            -webkit-column-break-inside: auto !important;
+            overflow-wrap: anywhere !important;
+            word-break: normal !important;
+        }
+        pre, code {
+            white-space: pre-wrap !important;
+            overflow-wrap: anywhere !important;
+        }
+        table {
+            table-layout: fixed !important;
+            width: 100% !important;
+            overflow-wrap: anywhere !important;
         }
         img.block-img {
             max-width: var(--hoshi-image-max-width, ${settings.imageMaxWidthFallbackCss}) !important;

--- a/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderPaginationScripts.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderPaginationScripts.kt
@@ -189,8 +189,10 @@ internal object ReaderPaginationScripts {
           document.head.appendChild(newViewport);
           var pageHeight = window.innerHeight + ${settings.bottomOverlapPx};
           var pageWidth = window.innerWidth;
+          var contentHeight = Math.max(1, window.innerHeight - ${settings.horizontalGlyphGuardPx});
           document.documentElement.style.setProperty('--page-height', pageHeight + 'px');
           document.documentElement.style.setProperty('--page-width', pageWidth + 'px');
+          document.documentElement.style.setProperty('--content-height', contentHeight + 'px');
           document.documentElement.style.setProperty('--hoshi-image-max-width', Math.max(1, Math.floor(pageWidth * ${settings.imageWidthViewportRatio})) + 'px');
           document.documentElement.style.setProperty('--hoshi-image-max-height', Math.max(1, pageHeight - ${settings.bottomOverlapPx}) + 'px');
           window.hoshiReader.pageHeight = pageHeight;

--- a/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderSettings.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderSettings.kt
@@ -1,6 +1,7 @@
 package moe.antimony.hoshi.features.reader
 
 import android.content.Context
+import kotlin.math.ceil
 import java.util.Locale
 
 data class ReaderSettings(
@@ -29,6 +30,13 @@ data class ReaderSettings(
     val bottomOverlapPx: Int
         get() = if (verticalWriting) fontSize else 0
 
+    val horizontalGlyphGuardPx: Int
+        get() = if (verticalWriting) {
+            0
+        } else {
+            ceil((fontSize * 0.4).coerceIn(10.0, 24.0)).toInt()
+        }
+
     val writingModeCss: String
         get() = if (verticalWriting) "vertical-rl" else "horizontal-tb"
 
@@ -40,6 +48,23 @@ data class ReaderSettings(
             val unit = if (verticalWriting) "vh" else "vw"
             val value = if (verticalWriting) verticalPadding else horizontalPadding
             return "calc(${value}${unit} + ${bottomOverlapPx}px)"
+        }
+
+    val columnWidthCss: String
+        get() = if (verticalWriting) {
+            "var(--page-width, 100vw)"
+        } else {
+            "calc(var(--page-width, 100vw) - ${horizontalPadding.toDouble().cssNumber()}vw)"
+        }
+
+    val bodyHeightCss: String
+        get() = "var(--content-height, ${bodyHeightFallbackCss})"
+
+    val bodyHeightFallbackCss: String
+        get() = if (horizontalGlyphGuardPx > 0) {
+            "calc(var(--page-height, 100vh) - ${horizontalGlyphGuardPx}px)"
+        } else {
+            "var(--page-height, 100vh)"
         }
 
     val pagePaddingCss: String

--- a/app/src/test/java/moe/antimony/hoshi/features/bookshelf/MainShellUiTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/features/bookshelf/MainShellUiTest.kt
@@ -24,6 +24,14 @@ class MainShellUiTest {
     }
 
     @Test
+    fun reportIssueUrlPointsAtAndroidRepository() {
+        assertEquals(
+            "https://github.com/HuangAntimony/Hoshi-Reader-Android/issues",
+            ReportIssueUrl,
+        )
+    }
+
+    @Test
     fun importedBooksAreDisplayedInUnshelvedSection() {
         val entries = listOf(
             BookEntry(

--- a/app/src/test/java/moe/antimony/hoshi/features/reader/ReaderSettingsTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/features/reader/ReaderSettingsTest.kt
@@ -51,9 +51,18 @@ class ReaderSettingsTest {
 
     @Test
     fun horizontalReaderCssUsesIosWritingModeMapping() {
-        val css = ReaderContentStyles.styleTag(ReaderSettings(verticalWriting = false))
+        val settings = ReaderSettings(verticalWriting = false)
+        val css = ReaderContentStyles.styleTag(settings)
+        val script = ReaderPaginationScripts.shellScript(settings = settings)
 
         assertTrue(css.contains("writing-mode: horizontal-tb !important;"))
+        assertEquals(10, settings.horizontalGlyphGuardPx)
+        assertTrue(css.contains("height: var(--content-height, calc(var(--page-height, 100vh) - 10px)) !important;"))
+        assertTrue(css.contains("column-width: calc(var(--page-width, 100vw) - 5.0vw) !important;"))
+        assertTrue(css.contains("column-fill: auto !important;"))
+        assertTrue(css.contains("overflow-wrap: anywhere !important;"))
+        assertTrue(script.contains("var contentHeight = Math.max(1, window.innerHeight - 10);"))
+        assertTrue(script.contains("--content-height"))
     }
 
     @Test

--- a/app/src/test/java/moe/antimony/hoshi/features/reader/ReaderSettingsTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/features/reader/ReaderSettingsTest.kt
@@ -57,6 +57,26 @@ class ReaderSettingsTest {
     }
 
     @Test
+    fun readerCssPreservesImageAspectRatio() {
+        val css = ReaderContentStyles.styleTag()
+        val imageCss = css.substringAfter("img.block-img {").substringBefore("}")
+        val svgCss = css.substringAfter("svg {").substringBefore("}")
+
+        assertTrue(css.contains("img.block-img"))
+        assertTrue(imageCss.contains("max-width: var(--hoshi-image-max-width"))
+        assertTrue(imageCss.contains("max-height: var(--hoshi-image-max-height"))
+        assertTrue(imageCss.contains("width: auto !important;"))
+        assertTrue(imageCss.contains("height: auto !important;"))
+        assertTrue(imageCss.contains("object-fit: contain !important;"))
+        assertFalse(imageCss.contains("\n            width: var(--hoshi-image-max-width"))
+        assertFalse(imageCss.contains("\n            height: var(--hoshi-image-max-height"))
+        assertTrue(svgCss.contains("width: auto !important;"))
+        assertTrue(svgCss.contains("height: auto !important;"))
+        assertFalse(svgCss.contains("width: 100% !important;"))
+        assertFalse(svgCss.contains("height: 100% !important;"))
+    }
+
+    @Test
     fun appInterfaceThemeMatchesIosColorSchemeMapping() {
         assertFalse(ReaderSettings(theme = ReaderTheme.Light).usesDarkInterface(systemDark = true))
         assertTrue(ReaderSettings(theme = ReaderTheme.Dark).usesDarkInterface(systemDark = false))


### PR DESCRIPTION
﻿## Summary
- Fix four reported Android issues and the horizontal reader text layout.
- Add Android CI for check, lint, unit tests, native build, debug APK assembly, and artifact upload.
- Keep release signing wired through GitHub Secrets via the existing signed release APK workflow.

## Validation
- Local: `./gradlew.bat check --console=plain --stacktrace`
- Local: `./gradlew.bat assembleDebug --console=plain --stacktrace`
- Local signed release smoke test with temporary test keystore: `./gradlew.bat assembleRelease --console=plain --stacktrace`
- Local signed APK verification: `apksigner verify --print-certs app/build/outputs/apk/release/app-release.apk`
- GitHub Actions on fork: Android CI succeeded, run 25103235908

## Notes
- Upstream direct push was denied for the authenticated account, so this branch was pushed to the fork `hdjsadgfwtg/Hoshi-Reader-Android`.
- Release signing requires repository secrets: `ANDROID_KEYSTORE_BASE64`, `ANDROID_KEYSTORE_PASSWORD`, `ANDROID_KEY_ALIAS`, and `ANDROID_KEY_PASSWORD`.
