### PR TITLE
[codex] Preserve reader image aspect ratios

### DIFF
--- a/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderContentStyles.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderContentStyles.kt
@@ -108,8 +108,8 @@ internal object ReaderContentStyles {
         img.block-img {
             max-width: var(--hoshi-image-max-width, ${settings.imageMaxWidthFallbackCss}) !important;
             max-height: var(--hoshi-image-max-height, ${settings.imageMaxHeightFallbackCss}) !important;
-            width: var(--hoshi-image-max-width, ${settings.imageMaxWidthFallbackCss}) !important;
-            height: var(--hoshi-image-max-height, ${settings.imageMaxHeightFallbackCss}) !important;
+            width: auto !important;
+            height: auto !important;
             display: block !important;
             margin: auto !important;
             break-inside: avoid !important;
@@ -119,8 +119,8 @@ internal object ReaderContentStyles {
         svg {
             max-width: var(--hoshi-image-max-width, ${settings.imageMaxWidthFallbackCss}) !important;
             max-height: var(--hoshi-image-max-height, ${settings.imageMaxHeightFallbackCss}) !important;
-            width: 100% !important;
-            height: 100% !important;
+            width: auto !important;
+            height: auto !important;
             display: block !important;
             margin: auto !important;
             break-inside: avoid !important;

--- a/app/src/test/java/moe/antimony/hoshi/features/reader/ReaderSettingsTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/features/reader/ReaderSettingsTest.kt
@@ -57,6 +57,26 @@ class ReaderSettingsTest {
     }
 
     @Test
+    fun readerCssPreservesImageAspectRatio() {
+        val css = ReaderContentStyles.styleTag()
+        val imageCss = css.substringAfter("img.block-img {").substringBefore("}")
+        val svgCss = css.substringAfter("svg {").substringBefore("}")
+
+        assertTrue(css.contains("img.block-img"))
+        assertTrue(imageCss.contains("max-width: var(--hoshi-image-max-width"))
+        assertTrue(imageCss.contains("max-height: var(--hoshi-image-max-height"))
+        assertTrue(imageCss.contains("width: auto !important;"))
+        assertTrue(imageCss.contains("height: auto !important;"))
+        assertTrue(imageCss.contains("object-fit: contain !important;"))
+        assertFalse(imageCss.contains("\n            width: var(--hoshi-image-max-width"))
+        assertFalse(imageCss.contains("\n            height: var(--hoshi-image-max-height"))
+        assertTrue(svgCss.contains("width: auto !important;"))
+        assertTrue(svgCss.contains("height: auto !important;"))
+        assertFalse(svgCss.contains("width: 100% !important;"))
+        assertFalse(svgCss.contains("height: 100% !important;"))
+    }
+
+    @Test
     fun appInterfaceThemeMatchesIosColorSchemeMapping() {
         assertFalse(ReaderSettings(theme = ReaderTheme.Light).usesDarkInterface(systemDark = true))
         assertTrue(ReaderSettings(theme = ReaderTheme.Dark).usesDarkInterface(systemDark = false))


### PR DESCRIPTION
﻿System.Collections.Hashtable.body

Validation:
- Included in fork Android CI success: https://github.com/hdjsadgfwtg/Hoshi-Reader-Android/actions/runs/25103235908
- Local validation previously passed: ./gradlew.bat check --console=plain --stacktrace
- Local validation previously passed: ./gradlew.bat assembleDebug --console=plain --stacktrace
