### PR TITLE
Fix issue report link / 修复问题反馈链接

### DIFF
--- a/app/src/main/java/moe/antimony/hoshi/features/bookshelf/BookshelfView.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/bookshelf/BookshelfView.kt
@@ -336,7 +336,7 @@ fun BookshelfView(
                         SettingsDestination.ReportIssue -> context.startActivity(
                             Intent(
                                 Intent.ACTION_VIEW,
-                                Uri.parse("https://github.com/Manhhao/Hoshi-Reader/issues"),
+                                Uri.parse(ReportIssueUrl),
                             ),
                         )
                         else -> settingsDestination = destination

--- a/app/src/main/java/moe/antimony/hoshi/features/bookshelf/MainShellUi.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/bookshelf/MainShellUi.kt
@@ -17,6 +17,8 @@ enum class SettingsDestination {
     About,
 }
 
+const val ReportIssueUrl = "https://github.com/HuangAntimony/Hoshi-Reader-Android/issues"
+
 data class SettingsRowModel(
     val label: String,
     val destination: SettingsDestination,

--- a/app/src/test/java/moe/antimony/hoshi/features/bookshelf/MainShellUiTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/features/bookshelf/MainShellUiTest.kt
@@ -24,6 +24,14 @@ class MainShellUiTest {
     }
 
     @Test
+    fun reportIssueUrlPointsAtAndroidRepository() {
+        assertEquals(
+            "https://github.com/HuangAntimony/Hoshi-Reader-Android/issues",
+            ReportIssueUrl,
+        )
+    }
+
+    @Test
     fun importedBooksAreDisplayedInUnshelvedSection() {
         val entries = listOf(
             BookEntry(


### PR DESCRIPTION
## Summary

Updates the in-app issue report link so it opens the Android repository issues page instead of pointing users to the wrong upstream location. The URL is covered by a stability test to prevent accidental regression.

## 概要

更新 App 内的问题反馈链接，使其打开 Android 仓库的 issues 页面，而不是把用户带到错误的上游位置。该 URL 已通过稳定性测试覆盖，避免后续误改回退。