### PR TITLE
Fix horizontal reader text layout / 修复横排阅读文字布局

### DIFF
--- a/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderContentStyles.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderContentStyles.kt
@@ -83,9 +83,12 @@ internal object ReaderContentStyles {
         $pageBreakCss
         @media (prefers-color-scheme: light) { :root { --hoshi-system-text-color: #000; } }
         @media (prefers-color-scheme: dark) { :root { --hoshi-system-text-color: #fff; } }
+        * {
+            max-width: 100% !important;
+            box-sizing: border-box !important;
+        }
         html, body {
             overflow: hidden !important;
-            height: var(--page-height, 100vh) !important;
             width: var(--page-width, 100vw) !important;
             margin: 0 !important;
             padding: 0 !important;
@@ -93,17 +96,42 @@ internal object ReaderContentStyles {
             color: $textColor !important;
             writing-mode: ${settings.writingModeCss} !important;
         }
+        html {
+            height: var(--page-height, 100vh) !important;
+        }
         body {
+            height: ${settings.bodyHeightCss} !important;
             font-family: $fontFamily, serif !important;
             font-size: ${settings.fontSize}px !important;
             $textSpacingCss
             box-sizing: border-box !important;
-            column-width: var(--page-width, 100vw) !important;
+            column-width: ${settings.columnWidthCss} !important;
             column-gap: ${settings.columnGapCss};
+            column-fill: auto !important;
+            -webkit-column-fill: auto !important;
+            overflow-wrap: anywhere !important;
+            word-break: normal !important;
+            orphans: 1;
+            widows: 1;
             padding: ${settings.pagePaddingCss} !important;
             padding-bottom: ${settings.bottomPaddingCss} !important;
             $gridCss
             text-orientation: mixed;
+        }
+        p, div, span, li {
+            break-inside: auto !important;
+            -webkit-column-break-inside: auto !important;
+            overflow-wrap: anywhere !important;
+            word-break: normal !important;
+        }
+        pre, code {
+            white-space: pre-wrap !important;
+            overflow-wrap: anywhere !important;
+        }
+        table {
+            table-layout: fixed !important;
+            width: 100% !important;
+            overflow-wrap: anywhere !important;
         }
         img.block-img {
             max-width: var(--hoshi-image-max-width, ${settings.imageMaxWidthFallbackCss}) !important;

--- a/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderPaginationScripts.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderPaginationScripts.kt
@@ -189,8 +189,10 @@ internal object ReaderPaginationScripts {
           document.head.appendChild(newViewport);
           var pageHeight = window.innerHeight + ${settings.bottomOverlapPx};
           var pageWidth = window.innerWidth;
+          var contentHeight = Math.max(1, window.innerHeight - ${settings.horizontalGlyphGuardPx});
           document.documentElement.style.setProperty('--page-height', pageHeight + 'px');
           document.documentElement.style.setProperty('--page-width', pageWidth + 'px');
+          document.documentElement.style.setProperty('--content-height', contentHeight + 'px');
           document.documentElement.style.setProperty('--hoshi-image-max-width', Math.max(1, Math.floor(pageWidth * ${settings.imageWidthViewportRatio})) + 'px');
           document.documentElement.style.setProperty('--hoshi-image-max-height', Math.max(1, pageHeight - ${settings.bottomOverlapPx}) + 'px');
           window.hoshiReader.pageHeight = pageHeight;

--- a/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderSettings.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderSettings.kt
@@ -1,6 +1,7 @@
 package moe.antimony.hoshi.features.reader
 
 import android.content.Context
+import kotlin.math.ceil
 import java.util.Locale
 
 data class ReaderSettings(
@@ -29,6 +30,13 @@ data class ReaderSettings(
     val bottomOverlapPx: Int
         get() = if (verticalWriting) fontSize else 0
 
+    val horizontalGlyphGuardPx: Int
+        get() = if (verticalWriting) {
+            0
+        } else {
+            ceil((fontSize * 0.4).coerceIn(10.0, 24.0)).toInt()
+        }
+
     val writingModeCss: String
         get() = if (verticalWriting) "vertical-rl" else "horizontal-tb"
 
@@ -40,6 +48,23 @@ data class ReaderSettings(
             val unit = if (verticalWriting) "vh" else "vw"
             val value = if (verticalWriting) verticalPadding else horizontalPadding
             return "calc(${value}${unit} + ${bottomOverlapPx}px)"
+        }
+
+    val columnWidthCss: String
+        get() = if (verticalWriting) {
+            "var(--page-width, 100vw)"
+        } else {
+            "calc(var(--page-width, 100vw) - ${horizontalPadding.toDouble().cssNumber()}vw)"
+        }
+
+    val bodyHeightCss: String
+        get() = "var(--content-height, ${bodyHeightFallbackCss})"
+
+    val bodyHeightFallbackCss: String
+        get() = if (horizontalGlyphGuardPx > 0) {
+            "calc(var(--page-height, 100vh) - ${horizontalGlyphGuardPx}px)"
+        } else {
+            "var(--page-height, 100vh)"
         }
 
     val pagePaddingCss: String

--- a/app/src/test/java/moe/antimony/hoshi/features/reader/ReaderSettingsTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/features/reader/ReaderSettingsTest.kt
@@ -51,9 +51,18 @@ class ReaderSettingsTest {
 
     @Test
     fun horizontalReaderCssUsesIosWritingModeMapping() {
-        val css = ReaderContentStyles.styleTag(ReaderSettings(verticalWriting = false))
+        val settings = ReaderSettings(verticalWriting = false)
+        val css = ReaderContentStyles.styleTag(settings)
+        val script = ReaderPaginationScripts.shellScript(settings = settings)
 
         assertTrue(css.contains("writing-mode: horizontal-tb !important;"))
+        assertEquals(10, settings.horizontalGlyphGuardPx)
+        assertTrue(css.contains("height: var(--content-height, calc(var(--page-height, 100vh) - 10px)) !important;"))
+        assertTrue(css.contains("column-width: calc(var(--page-width, 100vw) - 5.0vw) !important;"))
+        assertTrue(css.contains("column-fill: auto !important;"))
+        assertTrue(css.contains("overflow-wrap: anywhere !important;"))
+        assertTrue(script.contains("var contentHeight = Math.max(1, window.innerHeight - 10);"))
+        assertTrue(script.contains("--content-height"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes horizontal reader text layout so text flows and paginates correctly in horizontal reading mode. The change adjusts reader layout behavior to keep line sizing, page movement, and text positioning stable.

## 概要

修复横排阅读模式下的文字布局问题，让正文在横排模式中正确排版和翻页。该改动调整了阅读器布局行为，使行尺寸、页面移动和文字位置保持稳定。