### PR TITLE
Preserve reader image aspect ratios / 保持阅读器图片比例

### DIFF
--- a/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderContentStyles.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderContentStyles.kt
@@ -108,8 +108,8 @@ internal object ReaderContentStyles {
         img.block-img {
             max-width: var(--hoshi-image-max-width, ${settings.imageMaxWidthFallbackCss}) !important;
             max-height: var(--hoshi-image-max-height, ${settings.imageMaxHeightFallbackCss}) !important;
-            width: var(--hoshi-image-max-width, ${settings.imageMaxWidthFallbackCss}) !important;
-            height: var(--hoshi-image-max-height, ${settings.imageMaxHeightFallbackCss}) !important;
+            width: auto !important;
+            height: auto !important;
             display: block !important;
             margin: auto !important;
             break-inside: avoid !important;
@@ -119,8 +119,8 @@ internal object ReaderContentStyles {
         svg {
             max-width: var(--hoshi-image-max-width, ${settings.imageMaxWidthFallbackCss}) !important;
             max-height: var(--hoshi-image-max-height, ${settings.imageMaxHeightFallbackCss}) !important;
-            width: 100% !important;
-            height: 100% !important;
+            width: auto !important;
+            height: auto !important;
             display: block !important;
             margin: auto !important;
             break-inside: avoid !important;

--- a/app/src/test/java/moe/antimony/hoshi/features/reader/ReaderSettingsTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/features/reader/ReaderSettingsTest.kt
@@ -57,6 +57,26 @@ class ReaderSettingsTest {
     }
 
     @Test
+    fun readerCssPreservesImageAspectRatio() {
+        val css = ReaderContentStyles.styleTag()
+        val imageCss = css.substringAfter("img.block-img {").substringBefore("}")
+        val svgCss = css.substringAfter("svg {").substringBefore("}")
+
+        assertTrue(css.contains("img.block-img"))
+        assertTrue(imageCss.contains("max-width: var(--hoshi-image-max-width"))
+        assertTrue(imageCss.contains("max-height: var(--hoshi-image-max-height"))
+        assertTrue(imageCss.contains("width: auto !important;"))
+        assertTrue(imageCss.contains("height: auto !important;"))
+        assertTrue(imageCss.contains("object-fit: contain !important;"))
+        assertFalse(imageCss.contains("\n            width: var(--hoshi-image-max-width"))
+        assertFalse(imageCss.contains("\n            height: var(--hoshi-image-max-height"))
+        assertTrue(svgCss.contains("width: auto !important;"))
+        assertTrue(svgCss.contains("height: auto !important;"))
+        assertFalse(svgCss.contains("width: 100% !important;"))
+        assertFalse(svgCss.contains("height: 100% !important;"))
+    }
+
+    @Test
     fun appInterfaceThemeMatchesIosColorSchemeMapping() {
         assertFalse(ReaderSettings(theme = ReaderTheme.Light).usesDarkInterface(systemDark = true))
         assertTrue(ReaderSettings(theme = ReaderTheme.Dark).usesDarkInterface(systemDark = false))


### PR DESCRIPTION
## Summary

Fixes reader image rendering so inline images preserve their original aspect ratio instead of being stretched. This improves visual correctness for EPUB content that includes covers, illustrations, manga pages, or other embedded images.

## 概要

修复阅读器图片渲染问题，让正文内图片保持原始宽高比例，避免被拉伸变形。这会改善包含封面、插图、漫画页或其他嵌入图片的 EPUB 内容显示效果。