### PR TITLE
Add Android CI workflow / 添加 Android 自动编译流程

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,84 @@
+name: Android CI
+
+on:
+  push:
+    branches:
+      - main
+      - master
+      - develop
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: android-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    env:
+      ANDROID_NDK_VERSION: 28.2.13676358
+      ANDROID_CMAKE_VERSION: 3.22.1
+
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-linux-android,x86_64-linux-android
+
+      - name: Cache Cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/git
+            ~/.cargo/registry
+            app/src/main/rust/hoshiepub/target
+          key: cargo-${{ runner.os }}-${{ hashFiles('app/src/main/rust/hoshiepub/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: Install Android SDK components
+        run: |
+          sdkmanager --install \
+            "platforms;android-36.1" \
+            "build-tools;36.0.0" \
+            "ndk;${ANDROID_NDK_VERSION}" \
+            "cmake;${ANDROID_CMAKE_VERSION}"
+          echo "ANDROID_NDK_HOME=${ANDROID_HOME}/ndk/${ANDROID_NDK_VERSION}" >> "${GITHUB_ENV}"
+
+      - name: Install cargo-ndk
+        run: cargo install cargo-ndk --locked
+
+      - name: Build, lint, and unit test
+        run: ./gradlew check --console=plain --stacktrace
+
+      - name: Assemble debug APK
+        run: ./gradlew assembleDebug --console=plain --stacktrace
+
+      - name: Upload debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: hoshi-reader-debug-apk
+          path: app/build/outputs/apk/debug/*.apk
+          if-no-files-found: error

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -154,3 +154,4 @@
     - Add EPUB fixtures for cover, images, vertical text, horizontal text, complex spine, and broken resources.
     - Expand WebView pagination regression checks.
     - Keep Gradle `test`, `assembleDebug`, and `lint` passing before release-facing changes.
+    - `done` - Add Android CI workflow coverage for pull requests, running Gradle validation and debug APK assembly with the project native/Rust build requirements.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow for Android build and test verification. The workflow prepares the Android build environment, runs Gradle validation, and includes the native/Rust build requirements needed by this project.

## 概要

添加 GitHub Actions 工作流，用于 Android 自动构建和测试验证。该工作流会准备 Android 构建环境、运行 Gradle 校验，并包含本项目所需的 native/Rust 构建配置。