### PR TITLE
Fix Windows Gradle paths for Rust and UniFFI builds / 修复 Windows 下 Rust 和 UniFFI 的 Gradle 构建路径

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.compose)
@@ -7,8 +9,12 @@ plugins {
 val rustProjectDir = file("src/main/rust/hoshiepub")
 val uniffiOutDir = layout.buildDirectory.dir("generated/source/uniffi/main/kotlin").get().asFile
 val rustJniLibsDir = layout.buildDirectory.dir("jniLibs").get().asFile
-val cargo = System.getenv("HOME") + "/.cargo/bin/cargo"
-val androidNdkHome = System.getenv("ANDROID_NDK_HOME") ?: "/opt/homebrew/share/android-ndk"
+val localProperties = Properties().apply {
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.isFile) {
+        localPropertiesFile.inputStream().use { load(it) }
+    }
+}
 val releaseKeystorePath = providers.environmentVariable("ANDROID_KEYSTORE_FILE").orNull
 val releaseKeystorePassword = providers.environmentVariable("ANDROID_KEYSTORE_PASSWORD").orNull
 val releaseKeyAlias = providers.environmentVariable("ANDROID_KEY_ALIAS").orNull
@@ -30,10 +36,53 @@ if (isReleaseSigningRequested && !isReleaseSigningConfigured) {
     )
 }
 
+val osName = System.getProperty("os.name").lowercase()
+val isWindows = osName.contains("win")
+val sdkDir = localProperties.getProperty("sdk.dir")?.takeIf { it.isNotBlank() }
+    ?: providers.environmentVariable("ANDROID_HOME").orNull?.takeIf { it.isNotBlank() }
+    ?: providers.environmentVariable("ANDROID_SDK_ROOT").orNull?.takeIf { it.isNotBlank() }
+fun androidRevisionParts(directory: File): List<Int> =
+    Regex("\\d+").findAll(directory.name).map { it.value.toInt() }.toList()
+
+fun compareAndroidRevisions(left: File, right: File): Int {
+    val leftParts = androidRevisionParts(left)
+    val rightParts = androidRevisionParts(right)
+    for (index in 0 until maxOf(leftParts.size, rightParts.size)) {
+        val comparison = leftParts.getOrElse(index) { 0 }.compareTo(rightParts.getOrElse(index) { 0 })
+        if (comparison != 0) return comparison
+    }
+    return left.name.compareTo(right.name)
+}
+
+val androidNdkHome = providers.environmentVariable("ANDROID_NDK_HOME").orNull?.takeIf { it.isNotBlank() }
+    ?: localProperties.getProperty("ndk.dir")?.takeIf { it.isNotBlank() }
+    ?: sdkDir
+        ?.let { file("$it/ndk") }
+        ?.takeIf { it.isDirectory }
+        ?.listFiles()
+        ?.filter { it.isDirectory }
+        ?.maxWithOrNull(::compareAndroidRevisions)
+        ?.absolutePath
+    ?: "/opt/homebrew/share/android-ndk"
+val cargoBinaryName = if (isWindows) "cargo.exe" else "cargo"
+val cargo = providers.environmentVariable("CARGO").orNull?.takeIf { it.isNotBlank() }
+    ?: listOfNotNull(
+        System.getenv("HOME"),
+        System.getenv("USERPROFILE"),
+    ).asSequence()
+        .map { file("$it/.cargo/bin/$cargoBinaryName") }
+        .firstOrNull { it.isFile }
+        ?.absolutePath
+    ?: cargoBinaryName
+
 val hostLibExtension = when {
-    System.getProperty("os.name").lowercase().contains("mac") -> "dylib"
-    System.getProperty("os.name").lowercase().contains("win") -> "dll"
+    osName.contains("mac") -> "dylib"
+    isWindows -> "dll"
     else -> "so"
+}
+val hostLibName = when {
+    isWindows -> "hoshiepub.$hostLibExtension"
+    else -> "libhoshiepub.$hostLibExtension"
 }
 
 android {
@@ -135,7 +184,7 @@ val generateUniffiKotlin by tasks.registering(Exec::class) {
     dependsOn(buildRustHost)
     workingDir = rustProjectDir
 
-    val hostLibPath = rustProjectDir.resolve("target/debug/libhoshiepub.$hostLibExtension")
+    val hostLibPath = rustProjectDir.resolve("target/debug/$hostLibName")
 
     commandLine(
         cargo,

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -151,6 +151,8 @@
 
 11. `todo` - Regression coverage and release hardening
     - `done` - Add GitHub Actions signed APK release workflow for `v*` tags and manual dispatch, using repository signing secrets and uploading the APK plus GPLv3 `LICENSE` to the GitHub Release.
+    - `done` - Make Rust, UniFFI, and Android NDK Gradle paths portable across Windows and Unix hosts by resolving Cargo, SDK, NDK, and host library names from local properties and environment variables.
+    - Verified on Windows host and Android emulator: ran `.\gradlew.bat check --console=plain --stacktrace`, `.\gradlew.bat :app:assembleDebug --console=plain --stacktrace`, and `.\gradlew.bat :app:installDebug --console=plain --stacktrace`; launched `moe.antimony.hoshi/.MainActivity` on `emulator-5554` and confirmed the app stayed running on the Books screen without native library load failures.
     - Add EPUB fixtures for cover, images, vertical text, horizontal text, complex spine, and broken resources.
     - Expand WebView pagination regression checks.
     - Keep Gradle `test`, `assembleDebug`, and `lint` passing before release-facing changes.


### PR DESCRIPTION
This updates the Android Gradle build so Rust, UniFFI, and cargo-ndk resolve correctly on Windows as well as Unix hosts. Cargo is resolved from `CARGO`, `HOME`, or `USERPROFILE`; the Android NDK is resolved from `ANDROID_NDK_HOME`, `local.properties`, or the SDK NDK directory; UniFFI now uses the Windows host library name `hoshiepub.dll`; and the TODO tracker records the completed build-hardening slice.

这次更新 Android Gradle 构建，让 Rust、UniFFI 和 cargo-ndk 在 Windows 与 Unix 主机上都能正确解析路径。Cargo 会从 `CARGO`、`HOME` 或 `USERPROFILE` 中解析；Android NDK 会从 `ANDROID_NDK_HOME`、`local.properties` 或 SDK 的 NDK 目录中解析；UniFFI 在 Windows 上会使用正确的宿主库名 `hoshiepub.dll`；同时 TODO 中记录了这个构建加固切片的完成状态。