### PR TITLE
fix: stop the lookup popup overlay swallowing stylus input

### DIFF
--- a/app/src/main/java/moe/antimony/hoshi/features/dictionary/LookupPopupAndroidOverlay.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/dictionary/LookupPopupAndroidOverlay.kt
@@ -200,6 +200,7 @@ private class LookupPopupOverlayController(
 
     init {
         view.onOverlaySizeChanged = { lastUpdate?.let(::applyUpdate) }
+        view.onTapOutsidePopup = { dismissAllPopups() }
         view.addView(
             rootHighlightView,
             FrameLayout.LayoutParams(
@@ -208,6 +209,16 @@ private class LookupPopupOverlayController(
             ),
         )
         rootHost?.let { host -> view.addView(host) }
+    }
+
+    private fun dismissAllPopups() {
+        val update = lastUpdate ?: return
+        if (update.popups.isEmpty()) return
+        // Same path as the root popup's close button (dismiss at index 0): the reader
+        // handles it, falling back to clearing the popup list if it does not.
+        if (!update.onRootPopupDismissed()) {
+            update.onPopupsChange(emptyList())
+        }
     }
 
     fun update(
@@ -262,6 +273,13 @@ private class LookupPopupOverlayController(
     }
 
     private fun applyUpdate(update: OverlayUpdate) {
+        // The overlay sits on top of the reader WebView. With no popup to show it must be
+        // fully out of the input path — a VISIBLE full-screen overlay that merely returns
+        // false from dispatchTouchEvent still swallows Samsung S Pen input meant for the
+        // reader WebView behind it (regression from the v0.7.4 popup overlay rewrite).
+        // GONE keeps it clear of touch and hover dispatch until a popup actually needs it.
+        view.visibility = if (update.popups.isEmpty()) View.GONE else View.VISIBLE
+
         val rootPopup = if (warmRootEnabled) {
             update.popups.firstOrNull()
                 ?.withRootSelectionOffset(update.rootSelectionOffsetX, update.rootSelectionOffsetY)
@@ -373,6 +391,7 @@ private data class OverlayUpdate(
 
 private class LookupPopupOverlayLayout(context: Context) : FrameLayout(context) {
     var onOverlaySizeChanged: () -> Unit = {}
+    var onTapOutsidePopup: () -> Unit = {}
     private val touchStreamTracker = PopupTouchStreamTracker()
 
     override fun onSizeChanged(width: Int, height: Int, oldWidth: Int, oldHeight: Int) {
@@ -382,6 +401,13 @@ private class LookupPopupOverlayLayout(context: Context) : FrameLayout(context) 
 
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {
         val hitPopup = hitPopup(event)
+        // A press that misses every popup dismisses the stack. The overlay is GONE while
+        // no popup is shown, so reaching here means a popup is up. This must be handled
+        // here rather than left to fall through to the reader: an S Pen press does not
+        // fall through the overlay to the reader the way a finger press does.
+        if (!hitPopup && event.actionMasked == MotionEvent.ACTION_DOWN) {
+            onTapOutsidePopup()
+        }
         val shouldDispatch = touchStreamTracker.shouldDispatch(event.actionMasked, hitPopup)
         if (!shouldDispatch) return false
         val handled = super.dispatchTouchEvent(event)


### PR DESCRIPTION
## Problem

A stylus (Samsung S Pen) is completely dead inside the reader WebView — taps, scrolls and zoom all do nothing. A finger works normally in the reader, and the S Pen works fine on native UI and inside the lookup popup itself.

## Cause

The lookup popup overlay rewrite in v0.7.4 (#77) introduced `LookupPopupAndroidOverlay` — a full-screen native `View` overlay (`LookupPopupOverlayLayout`) that sits on top of the reader WebView **at all times**, even when no popup is shown. While idle it tries to be transparent by returning `false` from `dispatchTouchEvent`. That pass-through works for a finger, but a stylus press does **not** fall through the overlay to the reader WebView behind it — so the overlay silently swallows every S Pen event meant for the reader.

It also breaks "tap outside the popup to dismiss it": that was never explicit logic — it worked because the outside tap fell through to the reader, which cleared the selection. A stylus press never falls through, so an outside press never dismissed the popup.

## Fix

In `LookupPopupAndroidOverlay.kt`:

- Keep the overlay `GONE` while no popup is shown, so it is fully out of touch and hover dispatch and the reader WebView receives all input.
- Dismiss the popup stack from the overlay itself on a press that misses every popup, instead of relying on the press falling through to the reader.

## Testing

Verified on a Samsung S Pen device: reader tap-to-look-up, scrolling and zoom all work again with the S Pen, and tapping outside the popup dismisses it. Finger behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
