### PR TITLE
Add multilingual hoshidicts lookup support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,5 +4,5 @@
 	branch = develop
 [submodule "third_party/hoshidicts-kotlin-bridge"]
 	path = third_party/hoshidicts-kotlin-bridge
-	url = https://github.com/Manhhao/hoshidicts-kotlin-bridge.git
+	url = https://github.com/kaihouguide/hoshidicts-kotlin-bridge.git
 	branch = main

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -36,10 +36,10 @@ if (isReleaseSigningRequested && !isReleaseSigningConfigured) {
     )
 }
 
-val hostLibExtension = when {
-    System.getProperty("os.name").lowercase().contains("mac") -> "dylib"
-    System.getProperty("os.name").lowercase().contains("win") -> "dll"
-    else -> "so"
+val hostLibName = when {
+    System.getProperty("os.name").lowercase().contains("mac") -> "libhoshiepub.dylib"
+    System.getProperty("os.name").lowercase().contains("win") -> "hoshiepub.dll"
+    else -> "libhoshiepub.so"
 }
 
 android {
@@ -173,7 +173,7 @@ val buildRustHost by tasks.registering(Exec::class) {
         rustProjectDir.resolve("uniffi.toml"),
     )
     inputs.dir(rustProjectDir.resolve("src"))
-    outputs.file(rustProjectDir.resolve("target/debug/libhoshiepub.$hostLibExtension"))
+    outputs.file(rustProjectDir.resolve("target/debug/$hostLibName"))
 
     commandLine(cargo, "build", "--lib")
 }
@@ -182,7 +182,7 @@ val generateUniffiKotlin by tasks.registering(Exec::class) {
     dependsOn(buildRustHost)
     workingDir = rustProjectDir
 
-    val hostLibPath = rustProjectDir.resolve("target/debug/libhoshiepub.$hostLibExtension")
+    val hostLibPath = rustProjectDir.resolve("target/debug/$hostLibName")
 
     inputs.file(hostLibPath)
     inputs.file(rustProjectDir.resolve("uniffi.toml"))

--- a/app/src/main/java/de/manhhao/hoshi/HoshiDicts.kt
+++ b/app/src/main/java/de/manhhao/hoshi/HoshiDicts.kt
@@ -76,6 +76,7 @@ object HoshiDicts {
         pitchPaths: Array<String>,
     )
 
+    external fun setLookupLanguage(session: Long, language: String)
     external fun lookup(session: Long, text: String, maxResults: Int, scanLength: Int): Array<LookupResult>
     external fun getStyles(session: Long): Array<DictionaryStyle>
     external fun getMediaFile(session: Long, dictName: String, mediaPath: String): ByteArray?

--- a/app/src/main/java/moe/antimony/hoshi/HoshiAppContainer.kt
+++ b/app/src/main/java/moe/antimony/hoshi/HoshiAppContainer.kt
@@ -27,6 +27,8 @@ import moe.antimony.hoshi.features.dictionary.DictionarySettingsRepository
 import moe.antimony.hoshi.features.dictionary.DictionarySearchRepository
 import moe.antimony.hoshi.features.dictionary.DictionaryViewModelRepository
 import moe.antimony.hoshi.features.dictionary.dictionarySettingsRepository
+import moe.antimony.hoshi.features.profiles.LearningProfilesRepository
+import moe.antimony.hoshi.features.profiles.learningProfilesRepository
 import moe.antimony.hoshi.features.reader.ReaderFontManager
 import moe.antimony.hoshi.features.reader.ReaderSettingsRepository
 import moe.antimony.hoshi.features.reader.readerSettingsRepository
@@ -56,6 +58,7 @@ internal class HoshiAppContainer(context: Context) {
     val dictionaryRepository: DictionaryRepository = DictionaryRepository(appContext.filesDir)
     val readerSettingsRepository: ReaderSettingsRepository = appContext.readerSettingsRepository()
     val dictionarySettingsRepository: DictionarySettingsRepository = appContext.dictionarySettingsRepository()
+    val learningProfilesRepository: LearningProfilesRepository = appContext.learningProfilesRepository()
     val audioSettingsRepository: AudioSettingsRepository = appContext.audioSettingsRepository()
     val ankiSettingsRepository: AnkiSettingsRepository = appContext.ankiSettingsRepository()
     val sasayakiSettingsRepository: SasayakiSettingsRepository = appContext.sasayakiSettingsRepository()

--- a/app/src/main/java/moe/antimony/hoshi/dictionary/DictionaryRepository.kt
+++ b/app/src/main/java/moe/antimony/hoshi/dictionary/DictionaryRepository.kt
@@ -168,9 +168,9 @@ internal class DictionaryRepository(
         }
     }
 
-    fun lookup(text: String, maxResults: Int = 16, scanLength: Int = 16): List<LookupResult> {
+    fun lookup(text: String, maxResults: Int = 16, scanLength: Int = 16, language: String = "ja"): List<LookupResult> {
         ensureLookupQueryReady()
-        return LookupEngine.lookup(text, maxResults, scanLength)
+        return LookupEngine.lookup(text, maxResults, scanLength, language)
     }
 
     fun dictionaryStyles(): Map<String, String> {

--- a/app/src/main/java/moe/antimony/hoshi/dictionary/DictionaryRepository.kt
+++ b/app/src/main/java/moe/antimony/hoshi/dictionary/DictionaryRepository.kt
@@ -21,6 +21,14 @@ internal class DictionaryRepository(
     fun loadDictionaries(type: DictionaryType): List<DictionaryInfo> =
         storage.loadDictionaries(type)
 
+    fun currentConfig(): DictionaryConfig =
+        storage.currentConfig()
+
+    fun saveConfig(config: DictionaryConfig) {
+        storage.saveConfig(config)
+        rebuildLookupQuery()
+    }
+
     fun updatableDictionaries(): List<DictionaryUpdateCandidate> =
         storage.updatableDictionaries()
 

--- a/app/src/main/java/moe/antimony/hoshi/dictionary/LookupEngine.kt
+++ b/app/src/main/java/moe/antimony/hoshi/dictionary/LookupEngine.kt
@@ -5,8 +5,16 @@ import de.manhhao.hoshi.DictionaryStyle
 import de.manhhao.hoshi.LookupResult
 
 object LookupEngine {
-    fun lookup(text: String, maxResults: Int = 16, scanLength: Int = 16): List<LookupResult> =
-        HoshiDicts.lookup(HoshiDicts.lookupObject, text, maxResults, scanLength).toList()
+    fun lookup(
+        text: String,
+        maxResults: Int = 16,
+        scanLength: Int = 16,
+        language: String = "ja",
+    ): List<LookupResult> =
+        synchronized(HoshiDicts) {
+            HoshiDicts.setLookupLanguage(HoshiDicts.lookupObject, language)
+            HoshiDicts.lookup(HoshiDicts.lookupObject, text, maxResults, scanLength).toList()
+        }
 
     fun getStyles(): List<DictionaryStyle> =
         HoshiDicts.getStyles(HoshiDicts.lookupObject).toList()

--- a/app/src/main/java/moe/antimony/hoshi/features/bookshelf/BookshelfView.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/bookshelf/BookshelfView.kt
@@ -56,6 +56,7 @@ import androidx.compose.material.icons.rounded.Info
 import androidx.compose.material.icons.rounded.Inventory2
 import androidx.compose.material.icons.rounded.Keyboard
 import androidx.compose.material.icons.rounded.Palette
+import androidx.compose.material.icons.rounded.Person
 import androidx.compose.material.icons.rounded.RadioButtonUnchecked
 import androidx.compose.material.icons.rounded.ReportProblem
 import androidx.compose.material.icons.rounded.Settings
@@ -1763,6 +1764,7 @@ private fun BottomTabGlyph(tab: MainTab, modifier: Modifier = Modifier) {
 @Composable
 private fun SettingsGlyph(destination: SettingsDestination, color: Color, modifier: Modifier = Modifier) {
     val icon = when (destination) {
+        SettingsDestination.Profiles -> Icons.Rounded.Person
         SettingsDestination.Dictionaries -> Icons.AutoMirrored.Rounded.MenuBook
         SettingsDestination.Anki -> Icons.Rounded.Inventory2
         SettingsDestination.Appearance -> Icons.Rounded.Palette

--- a/app/src/main/java/moe/antimony/hoshi/features/bookshelf/MainShellUi.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/bookshelf/MainShellUi.kt
@@ -138,6 +138,7 @@ internal const val CollapsedShelfCoverSpacingDp = 12
 private const val CompletedProgressThreshold = 0.999
 
 enum class SettingsDestination {
+    Profiles,
     Dictionaries,
     Anki,
     Appearance,
@@ -177,6 +178,7 @@ data class BookshelfSectionModel(
 
 fun settingsGroups(): List<List<SettingsRowModel>> = listOf(
     listOf(
+        SettingsRowModel(R.string.settings_profiles, SettingsDestination.Profiles),
         SettingsRowModel(R.string.settings_dictionaries, SettingsDestination.Dictionaries),
         SettingsRowModel(R.string.settings_anki, SettingsDestination.Anki),
         SettingsRowModel(R.string.settings_appearance, SettingsDestination.Appearance),

--- a/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionarySearchView.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionarySearchView.kt
@@ -81,10 +81,12 @@ import kotlin.math.abs
 private const val DictionaryPopupTopInset = 118.0
 private const val DictionaryPopupBottomInset = 0.0
 
-internal fun dictionarySearchKeyboardOptions(): KeyboardOptions = KeyboardOptions(
+internal fun dictionarySearchKeyboardOptions(
+    language: DictionaryLanguage = DictionaryLanguage.Default,
+): KeyboardOptions = KeyboardOptions(
     imeAction = ImeAction.Search,
     showKeyboardOnFocus = true,
-    hintLocales = LocaleList(Locale("ja-JP")),
+    hintLocales = LocaleList(Locale(language.keyboardLocaleTag)),
 )
 
 internal fun dictionarySearchPopupOptions(
@@ -286,6 +288,7 @@ fun DictionarySearchView(
         DictionarySearchBar(
             query = uiState.query,
             isSearching = uiState.isSearching,
+            lookupLanguage = uiState.dictionarySettings.lookupLanguage,
             onQueryChange = searchViewModel::updateQuery,
             onSubmit = runLookup,
             modifier = Modifier
@@ -350,6 +353,7 @@ private fun Modifier.observeDictionaryHistorySwipe(
 private fun DictionarySearchBar(
     query: String,
     isSearching: Boolean,
+    lookupLanguage: DictionaryLanguage,
     onQueryChange: (String) -> Unit,
     onSubmit: () -> Unit,
     modifier: Modifier = Modifier,
@@ -412,7 +416,7 @@ private fun DictionarySearchBar(
                     scrollState = fieldScrollState,
                     textStyle = MaterialTheme.typography.titleLarge.copy(color = fieldForegroundColor),
                     cursorBrush = hoshiTextFieldCursorBrush(fieldForegroundColor),
-                    keyboardOptions = dictionarySearchKeyboardOptions(),
+                    keyboardOptions = dictionarySearchKeyboardOptions(lookupLanguage),
                     onKeyboardAction = { onSubmit() },
                 )
             }

--- a/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionarySearchViewModel.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionarySearchViewModel.kt
@@ -26,7 +26,7 @@ internal interface DictionarySearchRepository {
     val dictionarySettings: Flow<DictionarySettings>
     val audioSettings: Flow<AudioSettings>
     suspend fun rebuildLookupQuery()
-    fun lookup(query: String, maxResults: Int, scanLength: Int): List<LookupResult>
+    fun lookup(query: String, maxResults: Int, scanLength: Int, language: String): List<LookupResult>
     fun dictionaryStyles(): Map<String, String>
 }
 
@@ -42,8 +42,8 @@ internal class AndroidDictionarySearchRepository(
         dictionaryRepository.rebuildLookupQuery()
     }
 
-    override fun lookup(query: String, maxResults: Int, scanLength: Int): List<LookupResult> =
-        dictionaryRepository.lookup(query, maxResults, scanLength)
+    override fun lookup(query: String, maxResults: Int, scanLength: Int, language: String): List<LookupResult> =
+        dictionaryRepository.lookup(query, maxResults, scanLength, language)
 
     override fun dictionaryStyles(): Map<String, String> =
         dictionaryRepository.dictionaryStyles()
@@ -120,7 +120,14 @@ internal class DictionarySearchViewModel(
                         val styles = repository.dictionaryStyles()
                         DictionarySearchContent.runLookup(
                             query = query,
-                            lookup = { repository.lookup(it, dictionarySettings.maxResults, dictionarySettings.scanLength) },
+                            lookup = {
+                                repository.lookup(
+                                    it,
+                                    dictionarySettings.maxResults,
+                                    dictionarySettings.scanLength,
+                                    dictionarySettings.lookupLanguage.code,
+                                )
+                            },
                             assets = assets,
                             dictionaryStyles = styles,
                             dictionarySettings = dictionarySettings,
@@ -176,7 +183,7 @@ internal class DictionarySearchViewModel(
 
     fun lookupRedirect(query: String): List<LookupResult> {
         val settings = _uiState.value.dictionarySettings.normalized()
-        return repository.lookup(query, settings.maxResults, settings.scanLength)
+        return repository.lookup(query, settings.maxResults, settings.scanLength, settings.lookupLanguage.code)
     }
 
     fun recordLookupRedirected(count: Int) {

--- a/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionarySettings.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionarySettings.kt
@@ -28,7 +28,45 @@ enum class DictionaryCollapseMode(val rawValue: String, @get:StringRes val label
     }
 }
 
+enum class DictionaryLanguage(
+    val code: String,
+    val keyboardLocaleTag: String,
+    @get:StringRes val labelRes: Int,
+) {
+    Arabic("ar", "ar", R.string.dictionary_language_arabic),
+    German("de", "de-DE", R.string.dictionary_language_german),
+    ModernGreek("el", "el-GR", R.string.dictionary_language_modern_greek),
+    English("en", "en-US", R.string.dictionary_language_english),
+    Esperanto("eo", "eo", R.string.dictionary_language_esperanto),
+    Spanish("es", "es-ES", R.string.dictionary_language_spanish),
+    Basque("eu", "eu-ES", R.string.dictionary_language_basque),
+    French("fr", "fr-FR", R.string.dictionary_language_french),
+    Irish("ga", "ga-IE", R.string.dictionary_language_irish),
+    AncientGreek("grc", "grc", R.string.dictionary_language_ancient_greek),
+    Japanese("ja", "ja-JP", R.string.dictionary_language_japanese),
+    Georgian("kat", "ka-GE", R.string.dictionary_language_georgian),
+    Korean("ko", "ko-KR", R.string.dictionary_language_korean),
+    Latin("la", "la", R.string.dictionary_language_latin),
+    OldIrish("sga", "sga", R.string.dictionary_language_old_irish),
+    Albanian("sq", "sq-AL", R.string.dictionary_language_albanian),
+    Tagalog("tl", "tl-PH", R.string.dictionary_language_tagalog),
+    Yiddish("yi", "yi", R.string.dictionary_language_yiddish),
+    ;
+
+    companion object {
+        val Default = Japanese
+
+        fun fromCode(code: String?): DictionaryLanguage? =
+            entries.firstOrNull { it.code == code } ?: when (code) {
+                "ka" -> Georgian
+                "arz" -> Arabic
+                else -> null
+            }
+    }
+}
+
 data class DictionarySettings(
+    val lookupLanguage: DictionaryLanguage = DictionaryLanguage.Default,
     val dictionaryTabDefault: Boolean = false,
     val scanNonJapaneseText: Boolean = true,
     val maxResults: Int = 16,
@@ -65,6 +103,8 @@ class DictionarySettingsStore(context: Context) : DictionarySettingsLegacySource
     private val preferences = context.getSharedPreferences("dictionary-settings", Context.MODE_PRIVATE)
 
     override fun load(): DictionarySettings = DictionarySettings(
+        lookupLanguage = DictionaryLanguage.fromCode(preferences.getString(KEY_LOOKUP_LANGUAGE, null))
+            ?: DictionaryLanguage.Default,
         dictionaryTabDefault = preferences.getBoolean(KEY_DICTIONARY_TAB_DEFAULT, false),
         scanNonJapaneseText = preferences.getBoolean(KEY_SCAN_NON_JAPANESE_TEXT, true),
         maxResults = preferences.getInt(KEY_MAX_RESULTS, 16),
@@ -107,10 +147,12 @@ class DictionarySettingsStore(context: Context) : DictionarySettingsLegacySource
             .putBoolean(KEY_COMPACT_PITCH_ACCENTS, normalized.compactPitchAccents)
             .putBoolean(KEY_LOW_RAM_DICTIONARY_IMPORT, normalized.lowRamDictionaryImport)
             .putString(KEY_CUSTOM_CSS, normalized.customCSS)
+            .putString(KEY_LOOKUP_LANGUAGE, normalized.lookupLanguage.code)
             .apply()
     }
 
     private companion object {
+        const val KEY_LOOKUP_LANGUAGE = "lookupLanguage"
         const val KEY_DICTIONARY_TAB_DEFAULT = "dictionaryTabDefault"
         const val KEY_SCAN_NON_JAPANESE_TEXT = "scanNonJapaneseText"
         const val KEY_MAX_RESULTS = "maxResults"
@@ -165,6 +207,7 @@ class DictionarySettingsRepository(
     private fun Preferences.toDictionarySettings(): DictionarySettings {
         val legacyCollapseDictionaries = this[KEY_COLLAPSE_DICTIONARIES]
         return DictionarySettings(
+            lookupLanguage = DictionaryLanguage.fromCode(this[KEY_LOOKUP_LANGUAGE]) ?: DictionaryLanguage.Default,
             dictionaryTabDefault = this[KEY_DICTIONARY_TAB_DEFAULT] ?: false,
             scanNonJapaneseText = this[KEY_SCAN_NON_JAPANESE_TEXT] ?: true,
             maxResults = this[KEY_MAX_RESULTS] ?: 16,
@@ -203,6 +246,7 @@ class DictionarySettingsRepository(
         this[KEY_COMPACT_PITCH_ACCENTS] = normalized.compactPitchAccents
         this[KEY_LOW_RAM_DICTIONARY_IMPORT] = normalized.lowRamDictionaryImport
         this[KEY_CUSTOM_CSS] = normalized.customCSS
+        this[KEY_LOOKUP_LANGUAGE] = normalized.lookupLanguage.code
     }
 
     companion object {
@@ -210,6 +254,7 @@ class DictionarySettingsRepository(
 
         private val KEY_MIGRATED_FROM_SHARED_PREFERENCES =
             booleanPreferencesKey("dictionarySettingsMigratedFromSharedPreferences")
+        private val KEY_LOOKUP_LANGUAGE = stringPreferencesKey("lookupLanguage")
         private val KEY_DICTIONARY_TAB_DEFAULT = booleanPreferencesKey("dictionaryTabDefault")
         private val KEY_SCAN_NON_JAPANESE_TEXT = booleanPreferencesKey("scanNonJapaneseText")
         private val KEY_MAX_RESULTS = intPreferencesKey("maxResults")

--- a/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionaryView.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionaryView.kt
@@ -100,13 +100,16 @@ import androidx.compose.ui.zIndex
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewmodel.compose.viewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import moe.antimony.hoshi.LocalHoshiAppContainer
 import moe.antimony.hoshi.R
 import moe.antimony.hoshi.dictionary.DictionaryInfo
 import moe.antimony.hoshi.dictionary.DictionaryType
 import moe.antimony.hoshi.dictionary.RecommendedDictionaries
+import moe.antimony.hoshi.features.profiles.toProfileDictionarySelections
 import moe.antimony.hoshi.features.settings.SettingsDetailScaffold
 import moe.antimony.hoshi.features.reader.ReaderFontManager
 import moe.antimony.hoshi.importing.ImportFileType
@@ -313,6 +316,12 @@ fun DictionaryView(
                 settings = uiState.settings,
                 termDictionaries = uiState.dictionaries[DictionaryType.Term].orEmpty(),
                 onSettingsChange = dictionaryViewModel::updateSettings,
+                onLookupLanguageChange = { language ->
+                    dictionaryViewModel.updateSettings { current -> current.copy(lookupLanguage = language) }
+                    coroutineScope.launch {
+                        appContainer.learningProfilesRepository.updateActiveLookupLanguage(language)
+                    }
+                },
                 onClose = { destination = null },
                 modifier = modifier,
             )
@@ -526,7 +535,16 @@ fun DictionaryView(
                         }
                         DictionaryRow(
                             dictionary = dictionary,
-                            onEnabledChange = { dictionaryViewModel.setDictionaryEnabled(dictionary, it) },
+                            onEnabledChange = { enabled ->
+                                dictionaryViewModel.setDictionaryEnabled(dictionary, enabled) {
+                                    val selections = withContext(Dispatchers.IO) {
+                                        appContainer.dictionaryRepository
+                                            .currentConfig()
+                                            .toProfileDictionarySelections()
+                                    }
+                                    appContainer.learningProfilesRepository.updateActiveDictionarySelections(selections)
+                                }
+                            },
                             onDelete = {
                                 revealedFileName = null
                                 dictionaryViewModel.deleteDictionary(dictionary)
@@ -916,6 +934,7 @@ private fun DictionarySettingsView(
     settings: DictionarySettings,
     termDictionaries: List<DictionaryInfo>,
     onSettingsChange: ((DictionarySettings) -> DictionarySettings) -> Unit,
+    onLookupLanguageChange: (DictionaryLanguage) -> Unit,
     onClose: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -989,7 +1008,7 @@ private fun DictionarySettingsView(
                                     text = { Text(stringResource(language.labelRes)) },
                                     onClick = {
                                         languageMenuExpanded = false
-                                        onSettingsChange { current -> current.copy(lookupLanguage = language) }
+                                        onLookupLanguageChange(language)
                                     },
                                 )
                             }

--- a/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionaryView.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionaryView.kt
@@ -920,6 +920,7 @@ private fun DictionarySettingsView(
     modifier: Modifier = Modifier,
 ) {
     var showCollapsedDictionaries by remember { mutableStateOf(false) }
+    var languageMenuExpanded by remember { mutableStateOf(false) }
     if (showCollapsedDictionaries) {
         CollapsedDictionariesView(
             dictionaries = termDictionaries,
@@ -966,6 +967,35 @@ private fun DictionarySettingsView(
             item {
                 SectionLabel(stringResource(R.string.dictionary_settings_lookup))
                 SettingsGroup {
+                    Box {
+                        ListItem(
+                            modifier = Modifier.clickable { languageMenuExpanded = true },
+                            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                            headlineContent = { Text(stringResource(R.string.dictionary_lookup_language)) },
+                            supportingContent = { Text(stringResource(settings.lookupLanguage.labelRes)) },
+                            trailingContent = {
+                                Icon(
+                                    imageVector = Icons.Rounded.ChevronRight,
+                                    contentDescription = null,
+                                )
+                            },
+                        )
+                        DropdownMenu(
+                            expanded = languageMenuExpanded,
+                            onDismissRequest = { languageMenuExpanded = false },
+                        ) {
+                            DictionaryLanguage.entries.forEach { language ->
+                                DropdownMenuItem(
+                                    text = { Text(stringResource(language.labelRes)) },
+                                    onClick = {
+                                        languageMenuExpanded = false
+                                        onSettingsChange { current -> current.copy(lookupLanguage = language) }
+                                    },
+                                )
+                            }
+                        }
+                    }
+                    GroupDivider()
                     ToggleRow(stringResource(R.string.dictionary_scan_non_japanese), settings.scanNonJapaneseText) {
                         onSettingsChange { current -> current.copy(scanNonJapaneseText = it) }
                     }

--- a/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionaryViewModel.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionaryViewModel.kt
@@ -296,12 +296,17 @@ internal class DictionaryViewModel(
         }
     }
 
-    fun setDictionaryEnabled(dictionary: DictionaryInfo, enabled: Boolean) {
+    fun setDictionaryEnabled(
+        dictionary: DictionaryInfo,
+        enabled: Boolean,
+        afterSaved: suspend () -> Unit = {},
+    ) {
         val type = _uiState.value.selectedType
         scope.launch {
             withContext(ioDispatcher) {
                 repository.setDictionaryEnabled(type, dictionary.path.name, enabled)
             }
+            afterSaved()
             reloadDictionaries(clearError = false)
         }
     }

--- a/app/src/main/java/moe/antimony/hoshi/features/dictionary/LookupPopupAndroidOverlay.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/dictionary/LookupPopupAndroidOverlay.kt
@@ -517,7 +517,12 @@ private class LookupPopupHostView(
                 selectionHighlightView.update(rects, state.darkMode, state.eInkMode)
             },
             onLookupRedirect = { query ->
-                LookupEngine.lookup(query, state.dictionarySettings.maxResults, state.dictionarySettings.scanLength)
+                LookupEngine.lookup(
+                    query,
+                    state.dictionarySettings.maxResults,
+                    state.dictionarySettings.scanLength,
+                    state.dictionarySettings.lookupLanguage.code,
+                )
             },
             onLookupRedirected = { count ->
                 if (count > 0) {

--- a/app/src/main/java/moe/antimony/hoshi/features/dictionary/LookupPopupStack.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/dictionary/LookupPopupStack.kt
@@ -68,12 +68,12 @@ internal fun createLookupPopupItem(
     selection: ReaderSelectionData,
     options: LookupPopupOptions,
     dictionaryStyles: Map<String, String>? = null,
-    lookup: (String, Int, Int) -> List<de.manhhao.hoshi.LookupResult> = LookupEngine::lookup,
+    lookup: (String, Int, Int, String) -> List<de.manhhao.hoshi.LookupResult> = LookupEngine::lookup,
 ): Pair<LookupPopupItem, Int>? {
     val settings = options.dictionarySettings.normalized()
     val styles = dictionaryStyles ?: currentDictionaryStyles()
     val results = runCatching {
-        lookup(selection.text, settings.maxResults, settings.scanLength)
+        lookup(selection.text, settings.maxResults, settings.scanLength, settings.lookupLanguage.code)
     }.getOrDefault(emptyList())
     val first = results.firstOrNull() ?: return null
     return LookupPopupItem(

--- a/app/src/main/java/moe/antimony/hoshi/features/dictionary/ProcessTextLookupActivity.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/dictionary/ProcessTextLookupActivity.kt
@@ -113,6 +113,7 @@ private fun ProcessTextLookupOverlay(
                     query,
                     dictionarySettings.maxResults,
                     dictionarySettings.scanLength,
+                    dictionarySettings.lookupLanguage.code,
                 )
                 lookupPopupItem(
                     selection = selection,

--- a/app/src/main/java/moe/antimony/hoshi/features/profiles/LearningProfilesRepository.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/profiles/LearningProfilesRepository.kt
@@ -1,0 +1,356 @@
+package moe.antimony.hoshi.features.profiles
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import moe.antimony.hoshi.dictionary.DictionaryConfig
+import moe.antimony.hoshi.features.dictionary.DictionaryLanguage
+
+data class LearningProfile(
+    val id: String,
+    val name: String,
+    val lookupLanguage: DictionaryLanguage,
+    val dictionarySelections: ProfileDictionarySelections? = null,
+)
+
+data class ProfileDictionarySelections(
+    val termEnabledFileNames: Set<String> = emptySet(),
+    val frequencyEnabledFileNames: Set<String> = emptySet(),
+    val pitchEnabledFileNames: Set<String> = emptySet(),
+)
+
+data class LearningProfilesState(
+    val profiles: List<LearningProfile> = listOf(defaultLearningProfile()),
+    val activeProfileId: String = DefaultProfileId,
+) {
+    val activeProfile: LearningProfile
+        get() = profiles.firstOrNull { it.id == activeProfileId } ?: profiles.first()
+
+    val hasSingleDefaultProfile: Boolean
+        get() = profiles.size == 1 && activeProfileId == DefaultProfileId
+
+    fun normalized(): LearningProfilesState {
+        val usedIds = mutableSetOf<String>()
+        val normalizedProfiles = profiles.mapIndexedNotNull { index, profile ->
+            val id = profile.id.trim().ifBlank { "profile-${index + 1}" }
+            if (!usedIds.add(id)) return@mapIndexedNotNull null
+            profile.copy(
+                id = id,
+                name = profile.name.trim().ifBlank { fallbackProfileName(index + 1) },
+            )
+        }.ifEmpty { listOf(defaultLearningProfile()) }
+        val safeActiveProfileId = activeProfileId.takeIf { id ->
+            normalizedProfiles.any { it.id == id }
+        } ?: normalizedProfiles.first().id
+        return copy(
+            profiles = normalizedProfiles,
+            activeProfileId = safeActiveProfileId,
+        )
+    }
+}
+
+private const val DefaultProfileId = "default"
+private const val DefaultProfileName = "Default"
+private val ProfilesJson = Json {
+    encodeDefaults = true
+    ignoreUnknownKeys = true
+}
+
+private fun defaultLearningProfile(): LearningProfile =
+    LearningProfile(
+        id = DefaultProfileId,
+        name = DefaultProfileName,
+        lookupLanguage = DictionaryLanguage.Default,
+    )
+
+private fun fallbackProfileName(index: Int): String =
+    if (index == 1) DefaultProfileName else "Profile $index"
+
+private val Context.learningProfilesDataStore by preferencesDataStore(
+    name = LearningProfilesRepository.DataStoreName,
+)
+
+fun Context.learningProfilesRepository(): LearningProfilesRepository =
+    LearningProfilesRepository(learningProfilesDataStore)
+
+class LearningProfilesRepository(
+    private val dataStore: DataStore<Preferences>,
+) {
+    val state: Flow<LearningProfilesState> = dataStore.data
+        .map { preferences -> preferences.toLearningProfilesState() }
+
+    suspend fun addProfile(name: String, lookupLanguage: DictionaryLanguage): LearningProfile {
+        return addProfile(
+            name = name,
+            lookupLanguage = lookupLanguage,
+            dictionarySelections = null,
+        )
+    }
+
+    suspend fun addProfile(
+        name: String,
+        lookupLanguage: DictionaryLanguage,
+        dictionarySelections: ProfileDictionarySelections?,
+    ): LearningProfile {
+        var createdProfile: LearningProfile? = null
+        dataStore.edit { preferences ->
+            val current = preferences.toLearningProfilesState()
+            val profile = LearningProfile(
+                id = current.nextProfileId(),
+                name = name.trim().ifBlank { fallbackProfileName(current.profiles.size + 1) },
+                lookupLanguage = lookupLanguage,
+                dictionarySelections = dictionarySelections,
+            )
+            val next = current.copy(
+                profiles = current.profiles + profile,
+                activeProfileId = profile.id,
+            ).normalized()
+            createdProfile = next.activeProfile
+            preferences.writeLearningProfilesState(next)
+        }
+        return checkNotNull(createdProfile)
+    }
+
+    suspend fun selectProfile(profileId: String): LearningProfile? {
+        return selectProfile(
+            profileId = profileId,
+            currentDictionarySelections = null,
+        )
+    }
+
+    suspend fun selectProfile(
+        profileId: String,
+        currentDictionarySelections: ProfileDictionarySelections?,
+    ): LearningProfile? {
+        var selectedProfile: LearningProfile? = null
+        dataStore.edit { preferences ->
+            val current = preferences.toLearningProfilesState()
+            if (current.profiles.none { it.id == profileId }) return@edit
+            val nextProfiles = if (currentDictionarySelections == null) {
+                current.profiles
+            } else {
+                current.profiles.map { profile ->
+                    if (profile.id == current.activeProfile.id) {
+                        profile.copy(dictionarySelections = currentDictionarySelections)
+                    } else {
+                        profile
+                    }
+                }
+            }
+            val next = current.copy(
+                profiles = nextProfiles,
+                activeProfileId = profileId,
+            ).normalized()
+            selectedProfile = next.activeProfile
+            preferences.writeLearningProfilesState(next)
+        }
+        return selectedProfile
+    }
+
+    suspend fun updateProfile(
+        profileId: String,
+        name: String,
+        lookupLanguage: DictionaryLanguage,
+    ): LearningProfile? {
+        var updatedProfile: LearningProfile? = null
+        dataStore.edit { preferences ->
+            val current = preferences.toLearningProfilesState()
+            val nextProfiles = current.profiles.map { profile ->
+                if (profile.id == profileId) {
+                    profile.copy(
+                        name = name.trim().ifBlank { profile.name },
+                        lookupLanguage = lookupLanguage,
+                    )
+                } else {
+                    profile
+                }
+            }
+            val next = current.copy(profiles = nextProfiles).normalized()
+            updatedProfile = next.profiles.firstOrNull { it.id == profileId }
+            preferences.writeLearningProfilesState(next)
+        }
+        return updatedProfile
+    }
+
+    suspend fun deleteProfile(profileId: String): LearningProfile {
+        var activeProfile: LearningProfile? = null
+        dataStore.edit { preferences ->
+            val current = preferences.toLearningProfilesState()
+            if (current.profiles.size <= 1) {
+                activeProfile = current.activeProfile
+                return@edit
+            }
+            val nextProfiles = current.profiles.filterNot { it.id == profileId }
+            if (nextProfiles.size == current.profiles.size) {
+                activeProfile = current.activeProfile
+                return@edit
+            }
+            val next = current.copy(
+                profiles = nextProfiles,
+                activeProfileId = if (current.activeProfileId == profileId) {
+                    nextProfiles.first().id
+                } else {
+                    current.activeProfileId
+                },
+            ).normalized()
+            activeProfile = next.activeProfile
+            preferences.writeLearningProfilesState(next)
+        }
+        return checkNotNull(activeProfile)
+    }
+
+    suspend fun updateActiveDictionarySelections(dictionarySelections: ProfileDictionarySelections) {
+        dataStore.edit { preferences ->
+            val current = preferences.toLearningProfilesState()
+            val activeProfile = current.activeProfile
+            val nextProfiles = current.profiles.map { profile ->
+                if (profile.id == activeProfile.id) {
+                    profile.copy(dictionarySelections = dictionarySelections)
+                } else {
+                    profile
+                }
+            }
+            preferences.writeLearningProfilesState(current.copy(profiles = nextProfiles).normalized())
+        }
+    }
+
+    suspend fun updateActiveLookupLanguage(lookupLanguage: DictionaryLanguage) {
+        dataStore.edit { preferences ->
+            val current = preferences.toLearningProfilesState()
+            val activeProfile = current.activeProfile
+            if (activeProfile.lookupLanguage == lookupLanguage) return@edit
+            val nextProfiles = current.profiles.map { profile ->
+                if (profile.id == activeProfile.id) {
+                    profile.copy(lookupLanguage = lookupLanguage)
+                } else {
+                    profile
+                }
+            }
+            preferences.writeLearningProfilesState(current.copy(profiles = nextProfiles).normalized())
+        }
+    }
+
+    private fun LearningProfilesState.nextProfileId(): String {
+        var index = profiles.size + 1
+        while (profiles.any { it.id == "profile-$index" }) {
+            index += 1
+        }
+        return "profile-$index"
+    }
+
+    private fun Preferences.toLearningProfilesState(): LearningProfilesState {
+        val persisted = this[KEY_PROFILES_JSON]
+            ?.let { json ->
+                runCatching {
+                    ProfilesJson.decodeFromString<PersistedLearningProfilesState>(json)
+                }.getOrNull()
+            }
+        return persisted
+            ?.toLearningProfilesState()
+            ?.normalized()
+            ?: LearningProfilesState()
+    }
+
+    private fun MutablePreferences.writeLearningProfilesState(state: LearningProfilesState) {
+        this[KEY_PROFILES_JSON] = ProfilesJson.encodeToString(state.normalized().toPersisted())
+    }
+
+    companion object {
+        const val DataStoreName = "learning-profiles"
+        private val KEY_PROFILES_JSON = stringPreferencesKey("learningProfiles")
+    }
+}
+
+@Serializable
+private data class PersistedLearningProfilesState(
+    val profiles: List<PersistedLearningProfile> = emptyList(),
+    val activeProfileId: String = DefaultProfileId,
+) {
+    fun toLearningProfilesState(): LearningProfilesState =
+        LearningProfilesState(
+            profiles = profiles.map { profile ->
+                LearningProfile(
+                    id = profile.id,
+                    name = profile.name,
+                    lookupLanguage = DictionaryLanguage.fromCode(profile.lookupLanguage)
+                        ?: DictionaryLanguage.Default,
+                    dictionarySelections = profile.toDictionarySelections(),
+                )
+            },
+            activeProfileId = activeProfileId,
+        )
+}
+
+@Serializable
+private data class PersistedLearningProfile(
+    val id: String,
+    val name: String,
+    val lookupLanguage: String,
+    val termEnabledDictionaries: List<String>? = null,
+    val frequencyEnabledDictionaries: List<String>? = null,
+    val pitchEnabledDictionaries: List<String>? = null,
+)
+
+private fun LearningProfilesState.toPersisted(): PersistedLearningProfilesState =
+    PersistedLearningProfilesState(
+        profiles = profiles.map { profile ->
+            PersistedLearningProfile(
+                id = profile.id,
+                name = profile.name,
+                lookupLanguage = profile.lookupLanguage.code,
+                termEnabledDictionaries = profile.dictionarySelections?.termEnabledFileNames?.sorted(),
+                frequencyEnabledDictionaries = profile.dictionarySelections?.frequencyEnabledFileNames?.sorted(),
+                pitchEnabledDictionaries = profile.dictionarySelections?.pitchEnabledFileNames?.sorted(),
+            )
+        },
+        activeProfileId = activeProfileId,
+    )
+
+private fun PersistedLearningProfile.toDictionarySelections(): ProfileDictionarySelections? {
+    if (
+        termEnabledDictionaries == null &&
+        frequencyEnabledDictionaries == null &&
+        pitchEnabledDictionaries == null
+    ) {
+        return null
+    }
+    return ProfileDictionarySelections(
+        termEnabledFileNames = termEnabledDictionaries.orEmpty().toSet(),
+        frequencyEnabledFileNames = frequencyEnabledDictionaries.orEmpty().toSet(),
+        pitchEnabledFileNames = pitchEnabledDictionaries.orEmpty().toSet(),
+    )
+}
+
+fun DictionaryConfig.toProfileDictionarySelections(): ProfileDictionarySelections =
+    ProfileDictionarySelections(
+        termEnabledFileNames = termDictionaries.enabledFileNames(),
+        frequencyEnabledFileNames = frequencyDictionaries.enabledFileNames(),
+        pitchEnabledFileNames = pitchDictionaries.enabledFileNames(),
+    )
+
+fun DictionaryConfig.withProfileDictionarySelections(
+    selections: ProfileDictionarySelections,
+): DictionaryConfig =
+    copy(
+        termDictionaries = termDictionaries.withEnabledFileNames(selections.termEnabledFileNames),
+        frequencyDictionaries = frequencyDictionaries.withEnabledFileNames(selections.frequencyEnabledFileNames),
+        pitchDictionaries = pitchDictionaries.withEnabledFileNames(selections.pitchEnabledFileNames),
+    )
+
+private fun List<DictionaryConfig.DictionaryEntry>.enabledFileNames(): Set<String> =
+    filter { it.isEnabled }.map { it.fileName }.toSet()
+
+private fun List<DictionaryConfig.DictionaryEntry>.withEnabledFileNames(
+    enabledFileNames: Set<String>,
+): List<DictionaryConfig.DictionaryEntry> =
+    map { entry -> entry.copy(isEnabled = entry.fileName in enabledFileNames) }

--- a/app/src/main/java/moe/antimony/hoshi/features/profiles/LearningProfilesView.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/profiles/LearningProfilesView.kt
@@ -1,0 +1,399 @@
+package moe.antimony.hoshi.features.profiles
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Add
+import androidx.compose.material.icons.rounded.ChevronRight
+import androidx.compose.material.icons.rounded.Delete
+import androidx.compose.material.icons.rounded.Edit
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.ListItemDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import moe.antimony.hoshi.LocalHoshiAppContainer
+import moe.antimony.hoshi.R
+import moe.antimony.hoshi.features.dictionary.DictionaryLanguage
+import moe.antimony.hoshi.features.settings.GroupCard
+import moe.antimony.hoshi.features.settings.GroupDivider
+import moe.antimony.hoshi.features.settings.SectionTitle
+import moe.antimony.hoshi.features.settings.SettingsDetailScaffold
+import moe.antimony.hoshi.features.settings.collectAsLoadedSettings
+
+@Composable
+fun LearningProfilesView(
+    onClose: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val appContainer = LocalHoshiAppContainer.current
+    val profilesRepository = appContainer.learningProfilesRepository
+    val dictionarySettingsRepository = appContainer.dictionarySettingsRepository
+    val dictionaryRepository = appContainer.dictionaryRepository
+    val profilesState = profilesRepository.state.collectAsLoadedSettings()
+    val dictionarySettings = dictionarySettingsRepository.settings.collectAsLoadedSettings()
+    val scope = rememberCoroutineScope()
+    var showAddProfileDialog by remember { mutableStateOf(false) }
+    var editingProfile by remember { mutableStateOf<LearningProfile?>(null) }
+    var deletingProfile by remember { mutableStateOf<LearningProfile?>(null) }
+
+    LaunchedEffect(
+        profilesState?.activeProfile?.lookupLanguage,
+        dictionarySettings?.lookupLanguage,
+    ) {
+        val loadedProfilesState = profilesState ?: return@LaunchedEffect
+        val loadedDictionarySettings = dictionarySettings ?: return@LaunchedEffect
+        if (
+            loadedProfilesState.hasSingleDefaultProfile &&
+            loadedProfilesState.activeProfile.lookupLanguage != loadedDictionarySettings.lookupLanguage
+        ) {
+            profilesRepository.updateActiveLookupLanguage(loadedDictionarySettings.lookupLanguage)
+        }
+    }
+
+    LaunchedEffect(profilesState?.activeProfile?.id, profilesState?.activeProfile?.dictionarySelections) {
+        val loadedProfilesState = profilesState ?: return@LaunchedEffect
+        if (loadedProfilesState.activeProfile.dictionarySelections != null) return@LaunchedEffect
+        val currentSelections = withContext(Dispatchers.IO) {
+            dictionaryRepository.currentConfig().toProfileDictionarySelections()
+        }
+        profilesRepository.updateActiveDictionarySelections(currentSelections)
+    }
+
+    fun selectProfile(profile: LearningProfile) {
+        scope.launch {
+            val currentSelections = withContext(Dispatchers.IO) {
+                dictionaryRepository.currentConfig().toProfileDictionarySelections()
+            }
+            profilesRepository.selectProfile(profile.id, currentSelections)?.let { selectedProfile ->
+                dictionarySettingsRepository.update { settings ->
+                    settings.copy(lookupLanguage = selectedProfile.lookupLanguage)
+                }
+                selectedProfile.dictionarySelections?.let { selections ->
+                    withContext(Dispatchers.IO) {
+                        dictionaryRepository.saveConfig(
+                            dictionaryRepository.currentConfig().withProfileDictionarySelections(selections),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    val colorScheme = MaterialTheme.colorScheme
+    SettingsDetailScaffold(
+        title = stringResource(R.string.profiles_title),
+        onClose = onClose,
+        modifier = modifier.fillMaxSize(),
+        containerColor = colorScheme.background,
+        contentColor = colorScheme.onBackground,
+        actions = {
+            IconButton(onClick = { showAddProfileDialog = true }) {
+                Icon(
+                    imageVector = Icons.Rounded.Add,
+                    contentDescription = stringResource(R.string.profiles_add_profile),
+                )
+            }
+        },
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(18.dp),
+        ) {
+            item {
+                SectionTitle(stringResource(R.string.profiles_title))
+                GroupCard {
+                    val loadedProfilesState = profilesState
+                    if (loadedProfilesState == null) {
+                        ListItem(
+                            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                            headlineContent = { Text(stringResource(R.string.loading)) },
+                        )
+                    } else {
+                        loadedProfilesState.profiles.forEachIndexed { index, profile ->
+                            LearningProfileRow(
+                                profile = profile,
+                                isActive = profile.id == loadedProfilesState.activeProfileId,
+                                canDelete = loadedProfilesState.profiles.size > 1,
+                                onSelect = { selectProfile(profile) },
+                                onEdit = { editingProfile = profile },
+                                onDelete = { deletingProfile = profile },
+                            )
+                            if (index != loadedProfilesState.profiles.lastIndex) {
+                                GroupDivider()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showAddProfileDialog) {
+        ProfileEditorDialog(
+            title = stringResource(R.string.profiles_add_profile),
+            suggestedName = stringResource(
+                R.string.profiles_new_name_format,
+                (profilesState?.profiles?.size ?: 0) + 1,
+            ),
+            initialLanguage = dictionarySettings?.lookupLanguage
+                ?: profilesState?.activeProfile?.lookupLanguage
+                ?: DictionaryLanguage.Default,
+            onDismiss = { showAddProfileDialog = false },
+            onSave = { name, language ->
+                showAddProfileDialog = false
+                scope.launch {
+                    val currentSelections = withContext(Dispatchers.IO) {
+                        dictionaryRepository.currentConfig().toProfileDictionarySelections()
+                    }
+                    profilesRepository.addProfile(name, language, currentSelections)
+                    dictionarySettingsRepository.update { settings ->
+                        settings.copy(lookupLanguage = language)
+                    }
+                }
+            },
+        )
+    }
+
+    editingProfile?.let { profile ->
+        ProfileEditorDialog(
+            title = stringResource(R.string.profiles_edit_profile),
+            profile = profile,
+            suggestedName = profile.name,
+            initialLanguage = profile.lookupLanguage,
+            onDismiss = { editingProfile = null },
+            onSave = { name, language ->
+                editingProfile = null
+                scope.launch {
+                    val updatedProfile = profilesRepository.updateProfile(profile.id, name, language)
+                    if (profilesState?.activeProfileId == profile.id && updatedProfile != null) {
+                        dictionarySettingsRepository.update { settings ->
+                            settings.copy(lookupLanguage = updatedProfile.lookupLanguage)
+                        }
+                    }
+                }
+            },
+        )
+    }
+
+    deletingProfile?.let { profile ->
+        DeleteProfileDialog(
+            profile = profile,
+            onDismiss = { deletingProfile = null },
+            onConfirm = {
+                deletingProfile = null
+                scope.launch {
+                    val activeProfile = profilesRepository.deleteProfile(profile.id)
+                    if (profilesState?.activeProfileId == profile.id) {
+                        dictionarySettingsRepository.update { settings ->
+                            settings.copy(lookupLanguage = activeProfile.lookupLanguage)
+                        }
+                        activeProfile.dictionarySelections?.let { selections ->
+                            withContext(Dispatchers.IO) {
+                                dictionaryRepository.saveConfig(
+                                    dictionaryRepository.currentConfig().withProfileDictionarySelections(selections),
+                                )
+                            }
+                        }
+                    }
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun LearningProfileRow(
+    profile: LearningProfile,
+    isActive: Boolean,
+    canDelete: Boolean,
+    onSelect: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    ListItem(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onSelect),
+        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+        leadingContent = {
+            RadioButton(
+                selected = isActive,
+                onClick = onSelect,
+            )
+        },
+        headlineContent = {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = profile.name,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = if (isActive) FontWeight.SemiBold else FontWeight.Normal,
+                    modifier = Modifier.weight(1f),
+                )
+                if (isActive) {
+                    Text(
+                        text = stringResource(R.string.profiles_active),
+                        color = MaterialTheme.colorScheme.primary,
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+            }
+        },
+        supportingContent = {
+            Text(stringResource(profile.lookupLanguage.labelRes))
+        },
+        trailingContent = {
+            Row {
+                IconButton(onClick = onEdit) {
+                    Icon(
+                        imageVector = Icons.Rounded.Edit,
+                        contentDescription = stringResource(R.string.action_edit),
+                    )
+                }
+                if (canDelete) {
+                    IconButton(onClick = onDelete) {
+                        Icon(
+                            imageVector = Icons.Rounded.Delete,
+                            contentDescription = stringResource(R.string.action_delete),
+                        )
+                    }
+                }
+            }
+        },
+    )
+}
+
+@Composable
+private fun ProfileEditorDialog(
+    title: String,
+    suggestedName: String,
+    initialLanguage: DictionaryLanguage,
+    onDismiss: () -> Unit,
+    onSave: (String, DictionaryLanguage) -> Unit,
+    profile: LearningProfile? = null,
+) {
+    var name by remember(profile?.id, suggestedName) { mutableStateOf(profile?.name ?: suggestedName) }
+    var language by remember(profile?.id, initialLanguage) { mutableStateOf(initialLanguage) }
+    var languageMenuExpanded by remember { mutableStateOf(false) }
+    val trimmedName = name.trim()
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text(stringResource(R.string.profiles_name)) },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Box {
+                    ListItem(
+                        modifier = Modifier.clickable { languageMenuExpanded = true },
+                        colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                        headlineContent = { Text(stringResource(R.string.profiles_language)) },
+                        supportingContent = { Text(stringResource(language.labelRes)) },
+                        trailingContent = {
+                            Icon(
+                                imageVector = Icons.Rounded.ChevronRight,
+                                contentDescription = null,
+                            )
+                        },
+                    )
+                    DropdownMenu(
+                        expanded = languageMenuExpanded,
+                        onDismissRequest = { languageMenuExpanded = false },
+                    ) {
+                        DictionaryLanguage.entries.forEach { option ->
+                            DropdownMenuItem(
+                                text = { Text(stringResource(option.labelRes)) },
+                                onClick = {
+                                    language = option
+                                    languageMenuExpanded = false
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = { onSave(trimmedName, language) },
+                enabled = trimmedName.isNotEmpty(),
+            ) {
+                Text(stringResource(R.string.action_save))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun DeleteProfileDialog(
+    profile: LearningProfile,
+    onDismiss: () -> Unit,
+    onConfirm: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.profiles_delete_title_format, profile.name)) },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(stringResource(R.string.action_delete))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        },
+    )
+}

--- a/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderWebView.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderWebView.kt
@@ -708,6 +708,7 @@ fun ReaderWebView(
                     message.query,
                     popup.state.dictionarySettings.maxResults,
                     popup.state.dictionarySettings.scanLength,
+                    popup.state.dictionarySettings.lookupLanguage.code,
                 )
                 if (results.isNotEmpty()) {
                     setLookupPopups(

--- a/app/src/main/java/moe/antimony/hoshi/navigation/AppRoute.kt
+++ b/app/src/main/java/moe/antimony/hoshi/navigation/AppRoute.kt
@@ -35,6 +35,7 @@ sealed interface AppRoute : NavKey {
 
 @Serializable
 enum class SettingsDetailSection {
+    Profiles,
     Dictionaries,
     Anki,
     Appearance,

--- a/app/src/main/java/moe/antimony/hoshi/navigation/AppShell.kt
+++ b/app/src/main/java/moe/antimony/hoshi/navigation/AppShell.kt
@@ -37,6 +37,7 @@ import moe.antimony.hoshi.features.bookshelf.SettingsTab
 import moe.antimony.hoshi.features.diagnostics.DiagnosticsView
 import moe.antimony.hoshi.features.dictionary.DictionarySearchView
 import moe.antimony.hoshi.features.dictionary.DictionaryView
+import moe.antimony.hoshi.features.profiles.LearningProfilesView
 import moe.antimony.hoshi.features.reader.ReaderAppearanceScreen
 import moe.antimony.hoshi.features.reader.ReaderBehaviorScreen
 import moe.antimony.hoshi.features.reader.ReaderFontManager
@@ -332,6 +333,10 @@ private fun SettingsDetailDestination(
     onSelectedTabChange: (MainTab) -> Unit,
 ) {
     when (route.section) {
+        SettingsDetailSection.Profiles -> LearningProfilesView(
+            onClose = onClose,
+            modifier = Modifier.fillMaxSize(),
+        )
         SettingsDetailSection.Dictionaries -> DictionaryView(
             onClose = onClose,
             modifier = Modifier.fillMaxSize(),
@@ -380,6 +385,7 @@ private fun MainTab.toRoute(): AppRoute = when (this) {
 }
 
 private fun SettingsDestination.toSection(): SettingsDetailSection = when (this) {
+    SettingsDestination.Profiles -> SettingsDetailSection.Profiles
     SettingsDestination.Dictionaries -> SettingsDetailSection.Dictionaries
     SettingsDestination.Anki -> SettingsDetailSection.Anki
     SettingsDestination.Appearance -> SettingsDetailSection.Appearance

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -137,6 +137,25 @@
     <string name="dictionary_delete_action">删除辞典</string>
     <string name="dictionary_reorder_action">重新排序辞典</string>
     <string name="dictionary_settings_lookup">查词</string>
+    <string name="dictionary_lookup_language">&#x67E5;&#x8BCD;&#x8BED;&#x8A00;</string>
+    <string name="dictionary_language_arabic">&#x963F;&#x62C9;&#x4F2F;&#x8BED;</string>
+    <string name="dictionary_language_german">&#x5FB7;&#x8BED;</string>
+    <string name="dictionary_language_modern_greek">&#x73B0;&#x4EE3;&#x5E0C;&#x814A;&#x8BED;</string>
+    <string name="dictionary_language_english">&#x82F1;&#x8BED;</string>
+    <string name="dictionary_language_esperanto">&#x4E16;&#x754C;&#x8BED;</string>
+    <string name="dictionary_language_spanish">&#x897F;&#x73ED;&#x7259;&#x8BED;</string>
+    <string name="dictionary_language_basque">&#x5DF4;&#x65AF;&#x514B;&#x8BED;</string>
+    <string name="dictionary_language_french">&#x6CD5;&#x8BED;</string>
+    <string name="dictionary_language_irish">&#x7231;&#x5C14;&#x5170;&#x8BED;</string>
+    <string name="dictionary_language_ancient_greek">&#x53E4;&#x5E0C;&#x814A;&#x8BED;</string>
+    <string name="dictionary_language_japanese">&#x65E5;&#x8BED;</string>
+    <string name="dictionary_language_georgian">&#x683C;&#x9C81;&#x5409;&#x4E9A;&#x8BED;</string>
+    <string name="dictionary_language_korean">&#x97E9;&#x8BED;</string>
+    <string name="dictionary_language_latin">&#x62C9;&#x4E01;&#x8BED;</string>
+    <string name="dictionary_language_old_irish">&#x53E4;&#x7231;&#x5C14;&#x5170;&#x8BED;</string>
+    <string name="dictionary_language_albanian">&#x963F;&#x5C14;&#x5DF4;&#x5C3C;&#x4E9A;&#x8BED;</string>
+    <string name="dictionary_language_tagalog">&#x4ED6;&#x52A0;&#x7984;&#x8BED;</string>
+    <string name="dictionary_language_yiddish">&#x610F;&#x7B2C;&#x7EEA;&#x8BED;</string>
     <string name="dictionary_settings_import" comment="Dictionary settings section label, intentionally matching the Import action noun.">导入</string>
     <string name="dictionary_scan_non_japanese">扫描非日语文本</string>
     <string name="dictionary_max_results">最大结果数</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -47,6 +47,15 @@
     <string name="main_tab_settings" comment="Main navigation tab label, intentionally matching settings page titles.">设置</string>
     <string name="settings_dictionaries" comment="Settings row label, intentionally matching the backup Dictionaries section.">辞典</string>
     <string name="settings_anki">Anki</string>
+    <string name="settings_profiles">Profiles</string>
+    <string name="profiles_title">Profiles</string>
+    <string name="profiles_add_profile">Add Profile</string>
+    <string name="profiles_edit_profile">Edit Profile</string>
+    <string name="profiles_name">Profile Name</string>
+    <string name="profiles_language">Learning Language</string>
+    <string name="profiles_active">Active</string>
+    <string name="profiles_new_name_format">Profile %1$d</string>
+    <string name="profiles_delete_title_format">Delete \"%1$s\"?</string>
     <string name="settings_appearance">外观</string>
     <string name="settings_behavior">行为</string>
     <string name="settings_advanced">高级</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="main_tab_books" comment="Main navigation tab label, intentionally matching the backup Books section.">Books</string>
     <string name="main_tab_dictionary">Dictionary</string>
     <string name="main_tab_settings" comment="Main navigation tab label, intentionally matching settings page titles.">Settings</string>
+    <string name="settings_profiles">Profiles</string>
     <string name="settings_dictionaries" comment="Settings row label, intentionally matching the backup Dictionaries section.">Dictionaries</string>
     <string name="settings_anki">Anki</string>
     <string name="settings_appearance">Appearance</string>
@@ -59,6 +60,14 @@
     <string name="language_follow_system">Follow system</string>
     <string name="language_english" translatable="false">English</string>
     <string name="language_simplified_chinese" translatable="false">简体中文</string>
+    <string name="profiles_title">Profiles</string>
+    <string name="profiles_add_profile">Add Profile</string>
+    <string name="profiles_edit_profile">Edit Profile</string>
+    <string name="profiles_name">Profile Name</string>
+    <string name="profiles_language">Learning Language</string>
+    <string name="profiles_active">Active</string>
+    <string name="profiles_new_name_format">Profile %1$d</string>
+    <string name="profiles_delete_title_format">Delete \"%1$s\"?</string>
     <string name="bookshelf_open_failed">Failed to open EPUB.</string>
     <string name="bookshelf_import_failed">Failed to import EPUB.</string>
     <string name="bookshelf_import_failed_list_format" comment="Bookshelf batch import failure summary; intentionally matches the dictionary batch import format.">Failed to import:\n%1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -139,6 +139,25 @@
     <string name="dictionary_delete_action">Delete Dictionary</string>
     <string name="dictionary_reorder_action">Reorder Dictionary</string>
     <string name="dictionary_settings_lookup">Lookup</string>
+    <string name="dictionary_lookup_language">Lookup Language</string>
+    <string name="dictionary_language_arabic">Arabic</string>
+    <string name="dictionary_language_german">German</string>
+    <string name="dictionary_language_modern_greek">Modern Greek</string>
+    <string name="dictionary_language_english">English</string>
+    <string name="dictionary_language_esperanto">Esperanto</string>
+    <string name="dictionary_language_spanish">Spanish</string>
+    <string name="dictionary_language_basque">Basque</string>
+    <string name="dictionary_language_french">French</string>
+    <string name="dictionary_language_irish">Irish</string>
+    <string name="dictionary_language_ancient_greek">Ancient Greek</string>
+    <string name="dictionary_language_japanese">Japanese</string>
+    <string name="dictionary_language_georgian">Georgian</string>
+    <string name="dictionary_language_korean">Korean</string>
+    <string name="dictionary_language_latin">Latin</string>
+    <string name="dictionary_language_old_irish">Old Irish</string>
+    <string name="dictionary_language_albanian">Albanian</string>
+    <string name="dictionary_language_tagalog">Tagalog</string>
+    <string name="dictionary_language_yiddish">Yiddish</string>
     <string name="dictionary_settings_import" comment="Dictionary settings section label, intentionally matching the Import action noun.">Import</string>
     <string name="dictionary_scan_non_japanese">Scan Non-Japanese Text</string>
     <string name="dictionary_max_results">Max Results</string>

--- a/app/src/test/java/moe/antimony/hoshi/dictionary/DictionaryLookupQueryServiceTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/dictionary/DictionaryLookupQueryServiceTest.kt
@@ -9,16 +9,19 @@ class DictionaryLookupQueryServiceTest {
     fun rebuildForwardsEnabledPathsByDictionaryTypeToNativeBridge() {
         val bridge = RecordingDictionaryNativeBridge()
         val service = DictionaryLookupQueryService(bridge)
+        val termDictionary = File("/dicts/Term/JMdict")
+        val frequencyDictionary = File("/dicts/Frequency/Freq")
+        val pitchDictionary = File("/dicts/Pitch/Pitch")
 
         service.rebuild(
-            termDictionaries = listOf(File("/dicts/Term/JMdict")),
-            frequencyDictionaries = listOf(File("/dicts/Frequency/Freq")),
-            pitchDictionaries = listOf(File("/dicts/Pitch/Pitch")),
+            termDictionaries = listOf(termDictionary),
+            frequencyDictionaries = listOf(frequencyDictionary),
+            pitchDictionaries = listOf(pitchDictionary),
         )
 
-        assertArrayEquals(arrayOf("/dicts/Term/JMdict"), bridge.termPaths)
-        assertArrayEquals(arrayOf("/dicts/Frequency/Freq"), bridge.freqPaths)
-        assertArrayEquals(arrayOf("/dicts/Pitch/Pitch"), bridge.pitchPaths)
+        assertArrayEquals(arrayOf(termDictionary.absolutePath), bridge.termPaths)
+        assertArrayEquals(arrayOf(frequencyDictionary.absolutePath), bridge.freqPaths)
+        assertArrayEquals(arrayOf(pitchDictionary.absolutePath), bridge.pitchPaths)
     }
 
     private class RecordingDictionaryNativeBridge : DictionaryNativeBridge {

--- a/app/src/test/java/moe/antimony/hoshi/features/bookshelf/MainShellUiTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/features/bookshelf/MainShellUiTest.kt
@@ -32,6 +32,7 @@ class MainShellUiTest {
 
         assertEquals(
             listOf(
+                R.string.settings_profiles,
                 R.string.settings_dictionaries,
                 R.string.settings_anki,
                 R.string.settings_appearance,

--- a/app/src/test/java/moe/antimony/hoshi/features/dictionary/DictionarySearchViewModelTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/features/dictionary/DictionarySearchViewModelTest.kt
@@ -34,7 +34,11 @@ class DictionarySearchViewModelTest {
         val repository = FakeDictionarySearchRepository(
             lookupResults = listOf(lookupResult("猫")),
             dictionaryStyles = mapOf("JMdict" to ".entry {}"),
-            dictionarySettings = DictionarySettings(maxResults = 2, scanLength = 7),
+            dictionarySettings = DictionarySettings(
+                lookupLanguage = DictionaryLanguage.French,
+                maxResults = 2,
+                scanLength = 7,
+            ),
             audioSettings = AudioSettings(enableAutoplay = true),
         )
         val viewModel = viewModel(repository)
@@ -57,7 +61,7 @@ class DictionarySearchViewModelTest {
         assertTrue(state.hasSearched)
         assertFalse(state.isSearching)
         assertNull(state.errorMessage)
-        assertEquals(listOf("猫:2:7"), repository.lookupCalls)
+        assertEquals(listOf("猫:2:7:fr"), repository.lookupCalls)
         assertEquals(2, repository.rebuildCount)
         assertEquals(1, state.results.size)
         assertEquals("猫", state.results.single().matched)
@@ -128,7 +132,11 @@ class DictionarySearchViewModelTest {
         val repository = FakeDictionarySearchRepository(
             lookupResults = listOf(lookupResult("食べる")),
             dictionaryStyles = mapOf("Dict" to ".term {}"),
-            dictionarySettings = DictionarySettings(maxResults = 4, scanLength = 12),
+            dictionarySettings = DictionarySettings(
+                lookupLanguage = DictionaryLanguage.German,
+                maxResults = 4,
+                scanLength = 12,
+            ),
         )
         val viewModel = viewModel(repository)
         val highlightCount = viewModel.openRootPopup(
@@ -141,7 +149,7 @@ class DictionarySearchViewModelTest {
 
         assertEquals(3, highlightCount)
         assertEquals(1, viewModel.uiState.value.popups.size)
-        assertEquals(listOf("食べる:4:12"), repository.lookupCalls)
+        assertEquals(listOf("食べる:4:12:de"), repository.lookupCalls)
 
         viewModel.recordLookupRedirected(2)
         viewModel.navigateBack()
@@ -239,8 +247,8 @@ private class FakeDictionarySearchRepository(
         rebuildCount += 1
     }
 
-    override fun lookup(query: String, maxResults: Int, scanLength: Int): List<LookupResult> {
-        lookupCalls += "$query:$maxResults:$scanLength"
+    override fun lookup(query: String, maxResults: Int, scanLength: Int, language: String): List<LookupResult> {
+        lookupCalls += "$query:$maxResults:$scanLength:$language"
         error?.let { throw it }
         return lookupResults
     }

--- a/app/src/test/java/moe/antimony/hoshi/features/dictionary/DictionarySettingsRepositoryTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/features/dictionary/DictionarySettingsRepositoryTest.kt
@@ -33,6 +33,7 @@ class DictionarySettingsRepositoryTest {
         val legacy = FakeLegacyDictionarySettingsSource(
             DictionarySettings(
                 dictionaryTabDefault = true,
+                lookupLanguage = DictionaryLanguage.French,
                 scanNonJapaneseText = false,
                 maxResults = 100,
                 scanLength = 0,
@@ -53,6 +54,7 @@ class DictionarySettingsRepositoryTest {
             val migrated = repository.settings.first()
 
             assertTrue(migrated.dictionaryTabDefault)
+            assertEquals(DictionaryLanguage.French, migrated.lookupLanguage)
             assertFalse(migrated.scanNonJapaneseText)
             assertEquals(50, migrated.maxResults)
             assertEquals(1, migrated.scanLength)
@@ -79,6 +81,7 @@ class DictionarySettingsRepositoryTest {
             repository.update {
                 it.copy(
                     dictionaryTabDefault = true,
+                    lookupLanguage = DictionaryLanguage.German,
                     scanNonJapaneseText = false,
                     maxResults = 0,
                     scanLength = 100,
@@ -98,6 +101,7 @@ class DictionarySettingsRepositoryTest {
             val saved = repository.settings.first()
 
             assertTrue(saved.dictionaryTabDefault)
+            assertEquals(DictionaryLanguage.German, saved.lookupLanguage)
             assertFalse(saved.scanNonJapaneseText)
             assertEquals(1, saved.maxResults)
             assertEquals(64, saved.scanLength)

--- a/app/src/test/java/moe/antimony/hoshi/features/dictionary/DictionarySettingsTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/features/dictionary/DictionarySettingsTest.kt
@@ -11,6 +11,7 @@ class DictionarySettingsTest {
     fun defaultsMatchIosUserConfig() {
         val settings = DictionarySettings()
 
+        assertEquals(DictionaryLanguage.Japanese, settings.lookupLanguage)
         assertFalse(settings.dictionaryTabDefault)
         assertTrue(settings.scanNonJapaneseText)
         assertEquals(16, settings.maxResults)

--- a/app/src/test/java/moe/antimony/hoshi/features/profiles/LearningProfilesRepositoryTest.kt
+++ b/app/src/test/java/moe/antimony/hoshi/features/profiles/LearningProfilesRepositoryTest.kt
@@ -1,0 +1,180 @@
+package moe.antimony.hoshi.features.profiles
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import moe.antimony.hoshi.dictionary.DictionaryConfig
+import moe.antimony.hoshi.features.dictionary.DictionaryLanguage
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+
+class LearningProfilesRepositoryTest {
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun emitsDefaultProfileWhenNoProfilesWereSaved() = runBlocking {
+        repository().use { repository ->
+            val state = repository.state.first()
+
+            assertEquals(1, state.profiles.size)
+            assertEquals("Default", state.activeProfile.name)
+            assertEquals(DictionaryLanguage.Japanese, state.activeProfile.lookupLanguage)
+            assertTrue(state.hasSingleDefaultProfile)
+        }
+    }
+
+    @Test
+    fun addsSelectsUpdatesAndDeletesProfiles() = runBlocking {
+        repository().use { repository ->
+            val frenchSelections = ProfileDictionarySelections(
+                termEnabledFileNames = setOf("FrenchTerms"),
+            )
+            val french = repository.addProfile("French", DictionaryLanguage.French, frenchSelections)
+            val spanish = repository.addProfile("Spanish", DictionaryLanguage.Spanish)
+
+            assertEquals(spanish.id, repository.state.first().activeProfileId)
+            assertEquals(DictionaryLanguage.Spanish, repository.state.first().activeProfile.lookupLanguage)
+
+            val selected = repository.selectProfile(french.id)
+            assertEquals(french.id, selected?.id)
+            assertEquals(frenchSelections, selected?.dictionarySelections)
+            assertEquals(DictionaryLanguage.French, repository.state.first().activeProfile.lookupLanguage)
+
+            val updated = repository.updateProfile(french.id, "French Reading", DictionaryLanguage.German)
+            assertEquals("French Reading", updated?.name)
+            assertEquals(DictionaryLanguage.German, repository.state.first().activeProfile.lookupLanguage)
+
+            val activeAfterDelete = repository.deleteProfile(french.id)
+            assertEquals("Default", activeAfterDelete.name)
+            assertEquals(activeAfterDelete.id, repository.state.first().activeProfileId)
+
+            repository.deleteProfile(spanish.id)
+            repository.deleteProfile(repository.state.first().activeProfileId)
+            assertEquals(1, repository.state.first().profiles.size)
+        }
+    }
+
+    @Test
+    fun ignoresUnknownProfileSelectionAndSyncsActiveLanguage() = runBlocking {
+        repository().use { repository ->
+            assertNull(repository.selectProfile("missing"))
+
+            repository.updateActiveLookupLanguage(DictionaryLanguage.Korean)
+
+            val state = repository.state.first()
+            assertEquals(DictionaryLanguage.Korean, state.activeProfile.lookupLanguage)
+            assertEquals(1, state.profiles.size)
+        }
+    }
+
+    @Test
+    fun profileSwitchPersistsCurrentDictionarySelectionsBeforeSelectingNextProfile() = runBlocking {
+        repository().use { repository ->
+            val german = repository.addProfile(
+                name = "German",
+                lookupLanguage = DictionaryLanguage.German,
+                dictionarySelections = ProfileDictionarySelections(termEnabledFileNames = setOf("GermanTerms")),
+            )
+            val currentGermanSelections = ProfileDictionarySelections(termEnabledFileNames = setOf("JMdict"))
+
+            repository.selectProfile("default", currentDictionarySelections = currentGermanSelections)
+
+            val state = repository.state.first()
+            assertEquals("default", state.activeProfileId)
+            assertEquals(
+                currentGermanSelections,
+                state.profiles.single { it.id == german.id }.dictionarySelections,
+            )
+        }
+    }
+
+    @Test
+    fun dictionaryConfigConversionsPreserveOrderAndApplyProfileEnabledStates() {
+        val config = DictionaryConfig(
+            termDictionaries = listOf(
+                DictionaryConfig.DictionaryEntry("JMdict", isEnabled = true, order = 0),
+                DictionaryConfig.DictionaryEntry("GermanTerms", isEnabled = false, order = 1),
+            ),
+            frequencyDictionaries = listOf(
+                DictionaryConfig.DictionaryEntry("Jiten", isEnabled = true, order = 0),
+            ),
+            pitchDictionaries = listOf(
+                DictionaryConfig.DictionaryEntry("Pitch", isEnabled = false, order = 0),
+            ),
+        )
+        val selections = ProfileDictionarySelections(
+            termEnabledFileNames = setOf("GermanTerms"),
+            pitchEnabledFileNames = setOf("Pitch"),
+        )
+
+        val applied = config.withProfileDictionarySelections(selections)
+
+        assertEquals(listOf("JMdict", "GermanTerms"), applied.termDictionaries.map { it.fileName })
+        assertEquals(listOf(false, true), applied.termDictionaries.map { it.isEnabled })
+        assertEquals(listOf(false), applied.frequencyDictionaries.map { it.isEnabled })
+        assertEquals(listOf(true), applied.pitchDictionaries.map { it.isEnabled })
+        assertEquals(selections, applied.toProfileDictionarySelections())
+    }
+
+    private fun repository(): RepositoryHandle {
+        val scope = CoroutineScope(Dispatchers.IO + Job())
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = scope,
+            produceFile = { tempFolder.newFile("learning-profiles.preferences_pb") },
+        )
+        return RepositoryHandle(LearningProfilesRepository(dataStore), scope)
+    }
+
+    private class RepositoryHandle(
+        private val repository: LearningProfilesRepository,
+        private val scope: CoroutineScope,
+    ) : AutoCloseable {
+        val state = repository.state
+
+        suspend fun addProfile(name: String, lookupLanguage: DictionaryLanguage): LearningProfile =
+            repository.addProfile(name, lookupLanguage)
+
+        suspend fun addProfile(
+            name: String,
+            lookupLanguage: DictionaryLanguage,
+            dictionarySelections: ProfileDictionarySelections?,
+        ): LearningProfile =
+            repository.addProfile(name, lookupLanguage, dictionarySelections)
+
+        suspend fun selectProfile(profileId: String): LearningProfile? =
+            repository.selectProfile(profileId)
+
+        suspend fun selectProfile(
+            profileId: String,
+            currentDictionarySelections: ProfileDictionarySelections?,
+        ): LearningProfile? =
+            repository.selectProfile(profileId, currentDictionarySelections)
+
+        suspend fun updateProfile(
+            profileId: String,
+            name: String,
+            lookupLanguage: DictionaryLanguage,
+        ): LearningProfile? =
+            repository.updateProfile(profileId, name, lookupLanguage)
+
+        suspend fun deleteProfile(profileId: String): LearningProfile =
+            repository.deleteProfile(profileId)
+
+        suspend fun updateActiveLookupLanguage(lookupLanguage: DictionaryLanguage) {
+            repository.updateActiveLookupLanguage(lookupLanguage)
+        }
+
+        override fun close() {
+            scope.cancel()
+        }
+    }
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@ The format follows a Keep a Changelog style, and release sections use Semantic V
 
 ## [Unreleased]
 
+### Added
+
+- Add a dictionary lookup language setting with multilingual hoshidicts lookup support across reader popups, recursive lookups, Dictionary search, and Android Process Text.
+
 ### Fixed
 
 - Prevent vertical reader text from prematurely wrapping after furigana, leaving blank space in the current column.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ The format follows a Keep a Changelog style, and release sections use Semantic V
 ### Added
 
 - Add a dictionary lookup language setting with multilingual hoshidicts lookup support across reader popups, recursive lookups, Dictionary search, and Android Process Text.
+- Add Settings profiles so users can switch between multiple learning languages and keep each profile's lookup language and enabled dictionaries separate.
 
 ### Fixed
 


### PR DESCRIPTION
## Summary

This PR adds multilingual hoshidicts lookup support to Hoshi Reader Android by wiring the app to the multilingual hoshidicts bridge and exposing a user-selectable dictionary lookup language in the dictionary settings UI.

The app can now pass the configured lookup language through the repository, lookup engine, popup overlays, search view, process-text lookup flow, and reader webview lookup path instead of assuming the previous single-language behavior.

Supported hoshidicts lookup languages from the port are:

- Arabic (`ar`)
- German (`de`)
- Greek (`el`)
- English (`en`)
- Esperanto (`eo`)
- Spanish (`es`)
- Basque (`eu`)
- French (`fr`)
- Irish (`ga`)
- Ancient Greek (`grc`)
- Japanese (`ja`)
- Georgian (`kat`)
- Korean (`ko`)
- Latin (`la`)
- Old Irish (`sga`)
- Albanian (`sq`)
- Tagalog (`tl`)
- Yiddish (`yi`)

## User-Facing Changes

- Adds a dictionary lookup language setting.
- Threads the selected language into dictionary search and popup lookup requests.
- Adds localized strings for the new dictionary language setting.
- Updates tests for lookup/search/settings flows to account for language selection.
- Updates the changelog with multilingual dictionary lookup support.

## Notes

- The extra experimental German lookup changes we had added after the Yomitan port were reverted. This branch uses the Yomitan-port behavior again for German and the rest of the language transform data.
- The bridge submodule points at the multilingual hoshidicts bridge fork so the Android app can build against the ported language data and language-selection JNI API.

## Testing

Ran locally on Windows with Android Studio JBR, Android SDK/NDK, Rust/Cargo, and VS Build Tools configured.

Commands run:

```powershell
ctest --test-dir build --output-on-failure
.\build\hoshidicts-language-tests.exe
gradlew.bat :app:testDebugUnitTest :app:assembleDebug
```

Results:

- hoshidicts CTest language suite passed.
- hoshidicts paragraph language test passed: 64 expected outputs from 54 paragraphs across all 18 languages.
- Android `:app:testDebugUnitTest` passed.
- Android `:app:assembleDebug` passed.
