### PR TITLE
feat(dictionary): add back navigation support for the dictionary tab

### DIFF
--- a/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionarySearchView.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/dictionary/DictionarySearchView.kt
@@ -3,6 +3,7 @@ package moe.antimony.hoshi.features.dictionary
 import android.annotation.SuppressLint
 import android.view.MotionEvent
 import android.webkit.WebView
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitEachGesture
@@ -517,6 +518,15 @@ fun DictionarySearchView(
         }
     }
     readerPopupBridgeHolder.callbacks = ReaderLookupPopupBridgeCallbacks(::handleReaderPopupBridgeMessage)
+
+    BackHandler(enabled = uiState.popups.isNotEmpty() || uiState.backCount > 0) {
+        if (uiState.popups.isNotEmpty()) {
+            childHistories = emptyMap()
+            searchViewModel.dismissRootPopup()
+        } else {
+            navigateRootIframeBack()
+        }
+    }
 
     Box(
         modifier = modifier


### PR DESCRIPTION
The dictionary tab tracked its own lookup history but ignored the system back button, so pressing back left the app instead of returning to the previous lookup. Add a BackHandler that dismisses an open popup, then steps back through the lookup history, before falling through to exit.