### PR TITLE
fix: export sasayaki audio when Android API < 31

### DIFF
--- a/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderWebView.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/reader/ReaderWebView.kt
@@ -744,13 +744,17 @@ fun ReaderWebView(
             is ReaderLookupPopupBridgeMessage.MineEntry -> {
                 val popup = popupById(message.popupId) ?: return
                 val messageId = message.messageId ?: return
-                val ankiContext = popup.sasayakiCue?.takeIf { ankiUiState.popupSettings.needsSasayakiAudio }?.let { cue ->
-                    popup.state.ankiContext.copy(
-                        sasayakiAudioPath = sasayakiPlayer?.exportCueAudio(cue, popup.state.selection.sentence)?.absolutePath,
-                    )
-                } ?: popup.state.ankiContext
-                ankiViewModel.mineEntryAsync(message.payloadJson, ankiContext) { mined ->
-                    replyReaderPopupMessage(message.popupId, messageId, mined.toString())
+                scope.launch(Dispatchers.IO) {
+                    val ankiContext = popup.sasayakiCue?.takeIf { ankiUiState.popupSettings.needsSasayakiAudio }?.let { cue ->
+                        popup.state.ankiContext.copy(
+                            sasayakiAudioPath = sasayakiPlayer?.exportCueAudio(cue, popup.state.selection.sentence)?.absolutePath,
+                        )
+                    } ?: popup.state.ankiContext
+                    withContext(Dispatchers.Main) {
+                        ankiViewModel.mineEntryAsync(message.payloadJson, ankiContext) { mined ->
+                            replyReaderPopupMessage(message.popupId, messageId, mined.toString())
+                        }
+                    }
                 }
             }
             is ReaderLookupPopupBridgeMessage.DuplicateCheck -> {

--- a/app/src/main/java/moe/antimony/hoshi/features/sasayaki/SasayakiCueAudioExporter.kt
+++ b/app/src/main/java/moe/antimony/hoshi/features/sasayaki/SasayakiCueAudioExporter.kt
@@ -2,8 +2,14 @@ package moe.antimony.hoshi.features.sasayaki
 
 import moe.antimony.hoshi.epub.SasayakiMatch
 
+import android.annotation.SuppressLint
 import android.content.Context
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.media.MediaMuxer
 import android.net.Uri
+import android.os.Build
 import android.os.Handler
 import android.os.HandlerThread
 import androidx.annotation.OptIn
@@ -31,6 +37,18 @@ internal class SasayakiCueAudioExporter(
     private val appContext = context.applicationContext
 
     fun export(
+        source: SasayakiPlaybackSource,
+        cue: SasayakiMatch,
+        range: SasayakiCueAudioRange,
+    ): File? {
+        return if (Build.VERSION.SDK_INT >= 31) {
+            exportWithTransformer(source, cue, range)
+        } else {
+            exportWithCodecs(source, cue, range)
+        }
+    }
+
+    private fun exportWithTransformer(
         source: SasayakiPlaybackSource,
         cue: SasayakiMatch,
         range: SasayakiCueAudioRange,
@@ -104,6 +122,189 @@ internal class SasayakiCueAudioExporter(
             transformerOutput.delete()
         }
     }.getOrNull()
+
+    @SuppressLint("WrongConstant")
+    private fun exportWithCodecs(
+        source: SasayakiPlaybackSource,
+        cue: SasayakiMatch,
+        range: SasayakiCueAudioRange,
+    ): File? = runCatching {
+        outputRoot.mkdirs()
+        val output = outputRoot.resolve(outputFileName(cue))
+        if (output.exists()) output.delete()
+
+        val extractor = MediaExtractor()
+        var decoder: MediaCodec? = null
+        var encoder: MediaCodec? = null
+        try {
+            extractor.setDataSource(appContext, source.uri, null)
+            val trackIndex = (0 until extractor.trackCount).firstOrNull { i ->
+                val format = extractor.getTrackFormat(i)
+                format.getString(MediaFormat.KEY_MIME)?.startsWith("audio/") == true
+            } ?: return@runCatching null
+            extractor.selectTrack(trackIndex)
+            val trackFormat = extractor.getTrackFormat(trackIndex)
+            val mime = trackFormat.getString(MediaFormat.KEY_MIME) ?: return@runCatching null
+
+            val startUs = (range.startTime * 1_000_000.0).toLong()
+            val endUs = (range.endTime * 1_000_000.0).toLong() + 500_000L
+            extractor.seekTo(startUs, MediaExtractor.SEEK_TO_CLOSEST_SYNC)
+
+            decoder = MediaCodec.createDecoderByType(mime)
+            decoder.configure(trackFormat, null, null, 0)
+            decoder.start()
+
+            val aacOut = java.io.ByteArrayOutputStream()
+            var sampleRate = 0
+            var channels = 0
+            var inputDone = false
+            var outputDone = false
+
+            while (!outputDone) {
+                if (!inputDone) {
+                    val inputIndex = decoder.dequeueInputBuffer(10_000L)
+                    if (inputIndex >= 0) {
+                        val inputBuf = decoder.getInputBuffer(inputIndex) ?: return@runCatching null
+                        inputBuf.clear()
+                        val sampleSize = extractor.readSampleData(inputBuf, 0)
+                        if (sampleSize < 0 || extractor.sampleTime > endUs) {
+                            decoder.queueInputBuffer(inputIndex, 0, 0, 0, MediaCodec.BUFFER_FLAG_END_OF_STREAM)
+                            inputDone = true
+                        } else {
+                            decoder.queueInputBuffer(inputIndex, 0, sampleSize, extractor.sampleTime, extractor.sampleFlags)
+                            extractor.advance()
+                        }
+                    }
+                }
+
+                val decBufInfo = android.media.MediaCodec.BufferInfo()
+                val decIndex = decoder.dequeueOutputBuffer(decBufInfo, 10_000L)
+                when {
+                    decIndex == MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                        val fmt = decoder.outputFormat
+                        sampleRate = fmt.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+                        channels = fmt.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+                        if (encoder == null) {
+                            val aacFormat = android.media.MediaFormat.createAudioFormat(
+                                MediaFormat.MIMETYPE_AUDIO_AAC, sampleRate, channels
+                            )
+                            aacFormat.setInteger(MediaFormat.KEY_AAC_PROFILE,
+                                android.media.MediaCodecInfo.CodecProfileLevel.AACObjectLC)
+                            aacFormat.setInteger(MediaFormat.KEY_BIT_RATE, 64000)
+                            aacFormat.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, 8 * 1024)
+                            encoder = MediaCodec.createEncoderByType(MediaFormat.MIMETYPE_AUDIO_AAC)
+                            encoder.configure(aacFormat, null, null, MediaCodec.CONFIGURE_FLAG_ENCODE)
+                            encoder.start()
+                        }
+                    }
+                    decIndex >= 0 -> {
+                        val outBuf = decoder.getOutputBuffer(decIndex) ?: return@runCatching null
+                        outBuf.position(decBufInfo.offset)
+                        outBuf.limit(decBufInfo.offset + decBufInfo.size)
+                        val pcm = ByteArray(decBufInfo.size)
+                        outBuf.get(pcm)
+                        val isEos = decBufInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0
+
+                        val enc = encoder ?: return@runCatching null
+                        val encInputIndex = enc.dequeueInputBuffer(10_000L)
+                        if (encInputIndex >= 0) {
+                            val encInputBuf = enc.getInputBuffer(encInputIndex) ?: return@runCatching null
+                            encInputBuf.clear()
+                            encInputBuf.put(pcm)
+                            enc.queueInputBuffer(encInputIndex, 0, pcm.size, decBufInfo.presentationTimeUs, 0)
+                        }
+
+                        val encBufInfo = android.media.MediaCodec.BufferInfo()
+                        var encIndex = enc.dequeueOutputBuffer(encBufInfo, 10_000L)
+                        while (encIndex >= 0) {
+                            if (encBufInfo.size > 0 && encBufInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG == 0) {
+                                val encOutBuf = enc.getOutputBuffer(encIndex) ?: return@runCatching null
+                                encOutBuf.position(encBufInfo.offset)
+                                encOutBuf.limit(encBufInfo.offset + encBufInfo.size)
+                                val frame = ByteArray(encBufInfo.size)
+                                encOutBuf.get(frame)
+                                aacOut.write(aacAdtsHeader(frame.size, sampleRate, channels))
+                                aacOut.write(frame)
+                            }
+                            enc.releaseOutputBuffer(encIndex, false)
+                            encIndex = enc.dequeueOutputBuffer(encBufInfo, 0)
+                        }
+
+                        decoder.releaseOutputBuffer(decIndex, false)
+                        if (isEos) {
+                            drainEncoder(enc, aacOut, sampleRate, channels)
+                            outputDone = true
+                        }
+                    }
+                    decIndex == MediaCodec.INFO_TRY_AGAIN_LATER -> {
+                        if (inputDone) {
+                            val enc = encoder
+                            if (enc != null) drainEncoder(enc, aacOut, sampleRate, channels)
+                            outputDone = true
+                        }
+                    }
+                }
+            }
+
+            if (aacOut.size() == 0) {
+                output.delete()
+                return@runCatching null
+            }
+
+            output.writeBytes(aacOut.toByteArray())
+            output.takeIf { it.isFile && it.length() > 0L }
+        } finally {
+            try { decoder?.stop(); decoder?.release() } catch (_: Exception) {}
+            try { encoder?.stop(); encoder?.release() } catch (_: Exception) {}
+            try { extractor.release() } catch (_: Exception) {}
+        }
+    }.getOrNull()
+
+    private fun aacAdtsHeader(frameSize: Int, sampleRate: Int, channels: Int): ByteArray {
+        val sampleRateIndex = when (sampleRate) {
+            96000 -> 0; 88200 -> 1; 64000 -> 2; 48000 -> 3
+            44100 -> 4; 32000 -> 5; 24000 -> 6; 22050 -> 7
+            16000 -> 8; 12000 -> 9; 11025 -> 10; 8000 -> 11
+            7350 -> 12; else -> 4
+        }
+        val profile = 1
+        val totalLen = frameSize + 7
+        return byteArrayOf(
+            0xFF.toByte(),
+            0xF1.toByte(),
+            ((profile and 0x03) shl 6 or ((sampleRateIndex and 0x0F) shl 2) or ((channels shr 2) and 0x01)).toByte(),
+            (((channels and 0x03) shl 6) or ((totalLen shr 11) and 0x03)).toByte(),
+            ((totalLen shr 3) and 0xFF).toByte(),
+            (((totalLen and 0x07) shl 5) or 0x1F).toByte(),
+            0xFC.toByte(),
+        )
+    }
+
+    private fun drainEncoder(enc: MediaCodec, aacOut: java.io.ByteArrayOutputStream, sampleRate: Int, channels: Int) {
+        val bufInfo = android.media.MediaCodec.BufferInfo()
+        var timeoutExtend = 3
+        while (timeoutExtend > 0) {
+            val index = enc.dequeueOutputBuffer(bufInfo, 50_000L)
+            when (index) {
+                MediaCodec.INFO_TRY_AGAIN_LATER -> timeoutExtend--
+                MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> timeoutExtend = 3
+                else -> if (index >= 0) {
+                    timeoutExtend = 3
+                    if (bufInfo.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0) return
+                    if (bufInfo.size > 0 && bufInfo.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG == 0) {
+                        val buf = enc.getOutputBuffer(index) ?: return
+                        buf.position(bufInfo.offset)
+                        buf.limit(bufInfo.offset + bufInfo.size)
+                        val frame = ByteArray(bufInfo.size)
+                        buf.get(frame)
+                        aacOut.write(aacAdtsHeader(frame.size, sampleRate, channels))
+                        aacOut.write(frame)
+                    }
+                    enc.releaseOutputBuffer(index, false)
+                }
+            }
+        }
+    }
 
     private fun editedMediaItem(
         source: SasayakiPlaybackSource,


### PR DESCRIPTION
- Move export off main thread to prevent ANR
- Add MediaCodec-based fallback path for API < 31 (Media3 Transformer requires API 31+)
- Increase endUs margin to 500ms to fix end truncation