### PR TITLE
fix: Remove HTML entities from text in ReaderTextFilter

### DIFF
--- a/app/src/main/java/moe/antimony/hoshi/epub/ReaderTextFilter.kt
+++ b/app/src/main/java/moe/antimony/hoshi/epub/ReaderTextFilter.kt
@@ -16,6 +16,7 @@ internal fun String.visibleReaderText(): String {
     text = text.replace(Regex("(?s)<rt[^>]*>.*?</rt>"), "")
     text = text.replace(Regex("(?s)<(script|style)[^>]*>.*?</\\1>"), "")
     text = text.replace(Regex("<[^>]+>"), "")
+    text = text.replace(Regex("&#[xX]?[0-9A-Fa-f]+;"), "")
     return text
         .replace("&nbsp;", " ")
         .replace("&amp;", "&")


### PR DESCRIPTION
Certain characters will cause the ebook and the audiobook to be out of sync (these can be seen in TMW uploads of 転スラ). This is the fix implemented by Manhhao in the iOS version ported to Android that I've been running in a local build for the last week or so.